### PR TITLE
[codex] Smoke test: add farewell helper and pytest src path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,4 +18,4 @@ where = ["src"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-
+pythonpath = ["src"]

--- a/src/daedalus_playground/__init__.py
+++ b/src/daedalus_playground/__init__.py
@@ -1,4 +1,3 @@
-from .greetings import greeting
+from .greetings import farewell, greeting
 
-__all__ = ["greeting"]
-
+__all__ = ["greeting", "farewell"]

--- a/src/daedalus_playground/greetings.py
+++ b/src/daedalus_playground/greetings.py
@@ -3,3 +3,8 @@ def greeting(name: str = "Daedalus") -> str:
     clean_name = name.strip() or "Daedalus"
     return f"Hello, {clean_name}!"
 
+
+def farewell(name: str = "Daedalus") -> str:
+    """Return a predictable farewell for smoke tests."""
+    clean_name = name.strip() or "Daedalus"
+    return f"Goodbye, {clean_name}!"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+"""Pytest configuration shared for this repository."""
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+SRC_STR = str(SRC)
+if SRC.is_dir() and SRC_STR not in sys.path:
+    sys.path.insert(0, SRC_STR)

--- a/tests/test_greetings.py
+++ b/tests/test_greetings.py
@@ -1,4 +1,4 @@
-from daedalus_playground import greeting
+from daedalus_playground import farewell, greeting
 
 
 def test_greeting_uses_default_name() -> None:
@@ -8,3 +8,14 @@ def test_greeting_uses_default_name() -> None:
 def test_greeting_trims_custom_name() -> None:
     assert greeting("  Hermes  ") == "Hello, Hermes!"
 
+
+def test_farewell_uses_default_name() -> None:
+    assert farewell() == "Goodbye, Daedalus!"
+
+
+def test_farewell_trims_custom_name() -> None:
+    assert farewell("  Hermes  ") == "Goodbye, Hermes!"
+
+
+def test_farewell_falls_back_on_blank_name() -> None:
+    assert farewell("   ") == "Goodbye, Daedalus!"


### PR DESCRIPTION
Implements issue #5. Generated by wrapper-owned workflow watchdog.