### PR TITLE
Add excited greeting helper

### DIFF
--- a/src/daedalus_playground/__init__.py
+++ b/src/daedalus_playground/__init__.py
@@ -1,3 +1,3 @@
-from .greetings import greeting, salutation
+from .greetings import excited_greeting, greeting, salutation
 
-__all__ = ["greeting", "salutation"]
+__all__ = ["excited_greeting", "greeting", "salutation"]

--- a/src/daedalus_playground/greetings.py
+++ b/src/daedalus_playground/greetings.py
@@ -4,6 +4,12 @@ def greeting(name: str = "Daedalus") -> str:
     return f"Hello, {clean_name}!"
 
 
+def excited_greeting(name: str = "Daedalus") -> str:
+    """Return an excited greeting for smoke tests."""
+    clean_name = name.strip() or "Daedalus"
+    return f"Hello, {clean_name}!!!"
+
+
 def salutation(name: str = "Daedalus") -> str:
     """Return the requested salutation helper."""
     return f"Salutations, {name}."

--- a/tests/test_greetings.py
+++ b/tests/test_greetings.py
@@ -1,4 +1,4 @@
-from daedalus_playground import greeting
+from daedalus_playground import excited_greeting, greeting
 
 
 def test_greeting_uses_default_name() -> None:
@@ -8,3 +8,14 @@ def test_greeting_uses_default_name() -> None:
 def test_greeting_trims_custom_name() -> None:
     assert greeting("  Hermes  ") == "Hello, Hermes!"
 
+
+def test_excited_greeting_uses_default_name() -> None:
+    assert excited_greeting() == "Hello, Daedalus!!!"
+
+
+def test_excited_greeting_trims_custom_name() -> None:
+    assert excited_greeting("  Hermes  ") == "Hello, Hermes!!!"
+
+
+def test_excited_greeting_falls_back_for_blank_name() -> None:
+    assert excited_greeting("   ") == "Hello, Daedalus!!!"


### PR DESCRIPTION
## Summary
- Add exported excited_greeting helper with whitespace trimming and blank fallback
- Cover default, trimmed custom, and blank-name behavior in pytest

## Validation
- PYTHONPATH=src pytest

Closes #22