### PR TITLE
Add farewell helper

### DIFF
--- a/src/daedalus_playground/__init__.py
+++ b/src/daedalus_playground/__init__.py
@@ -1,3 +1,3 @@
-from .greetings import greeting, salutation
+from .greetings import farewell, greeting, salutation
 
-__all__ = ["greeting", "salutation"]
+__all__ = ["farewell", "greeting", "salutation"]

--- a/src/daedalus_playground/greetings.py
+++ b/src/daedalus_playground/greetings.py
@@ -4,6 +4,12 @@ def greeting(name: str = "Daedalus") -> str:
     return f"Hello, {clean_name}!"
 
 
+def farewell(name: str = "Daedalus") -> str:
+    """Return a predictable farewell for smoke tests."""
+    clean_name = name.strip() or "Daedalus"
+    return f"Goodbye, {clean_name}."
+
+
 def salutation(name: str = "Daedalus") -> str:
     """Return the requested salutation helper."""
     return f"Salutations, {name}."

--- a/tests/test_farewell.py
+++ b/tests/test_farewell.py
@@ -1,0 +1,13 @@
+from daedalus_playground import farewell
+
+
+def test_farewell_uses_default_name() -> None:
+    assert farewell() == "Goodbye, Daedalus."
+
+
+def test_farewell_trims_custom_name() -> None:
+    assert farewell("  Hermes  ") == "Goodbye, Hermes."
+
+
+def test_farewell_falls_back_for_blank_name() -> None:
+    assert farewell("   ") == "Goodbye, Daedalus."


### PR DESCRIPTION
## Summary
- add exported farewell helper with Daedalus default fallback
- trim custom names and handle blank input
- add focused pytest coverage for farewell behavior

## Validation
- python3 -m pip install -e .[test] --break-system-packages
- pytest

Closes #26