### PR TITLE
Add polite greeting helper

### DIFF
--- a/src/daedalus_playground/__init__.py
+++ b/src/daedalus_playground/__init__.py
@@ -1,3 +1,3 @@
-from .greetings import greeting, salutation
+from .greetings import greeting, polite_greeting, salutation
 
-__all__ = ["greeting", "salutation"]
+__all__ = ["greeting", "polite_greeting", "salutation"]

--- a/src/daedalus_playground/greetings.py
+++ b/src/daedalus_playground/greetings.py
@@ -7,3 +7,9 @@ def greeting(name: str = "Daedalus") -> str:
 def salutation(name: str = "Daedalus") -> str:
     """Return the requested salutation helper."""
     return f"Salutations, {name}."
+
+
+def polite_greeting(name: str = "Daedalus") -> str:
+    """Return a polite greeting with a fallback name."""
+    clean_name = name.strip() or "Daedalus"
+    return f"Good day, {clean_name}."

--- a/tests/test_polite_greeting.py
+++ b/tests/test_polite_greeting.py
@@ -1,0 +1,13 @@
+from daedalus_playground import polite_greeting
+
+
+def test_polite_greeting_uses_default_name() -> None:
+    assert polite_greeting() == "Good day, Daedalus."
+
+
+def test_polite_greeting_trims_custom_name() -> None:
+    assert polite_greeting("  Hermes  ") == "Good day, Hermes."
+
+
+def test_polite_greeting_uses_default_for_blank_name() -> None:
+    assert polite_greeting("   ") == "Good day, Daedalus."


### PR DESCRIPTION
## Summary
- add exported polite_greeting helper with whitespace trimming and blank-name fallback
- cover default, trimmed, and blank-name behavior with focused pytest tests

## Validation
- python3 -m pip install -e .[test] --break-system-packages
- pytest

Closes #28