### PR TITLE
Add shared name normalization helper

### DIFF
--- a/src/daedalus_playground/greetings.py
+++ b/src/daedalus_playground/greetings.py
@@ -1,9 +1,15 @@
+def _normalize_name(name: str) -> str:
+    clean_name = name.strip()
+    return clean_name or "Daedalus"
+
+
 def greeting(name: str = "Daedalus") -> str:
     """Return a predictable greeting for smoke tests."""
-    clean_name = name.strip() or "Daedalus"
+    clean_name = _normalize_name(name)
     return f"Hello, {clean_name}!"
 
 
 def salutation(name: str = "Daedalus") -> str:
     """Return the requested salutation helper."""
-    return f"Salutations, {name}."
+    clean_name = _normalize_name(name)
+    return f"Salutations, {clean_name}."

--- a/tests/test_greetings.py
+++ b/tests/test_greetings.py
@@ -8,3 +8,6 @@ def test_greeting_uses_default_name() -> None:
 def test_greeting_trims_custom_name() -> None:
     assert greeting("  Hermes  ") == "Hello, Hermes!"
 
+
+def test_greeting_uses_default_for_blank_name() -> None:
+    assert greeting("   ") == "Hello, Daedalus!"

--- a/tests/test_salutation.py
+++ b/tests/test_salutation.py
@@ -7,3 +7,11 @@ def test_salutation_uses_default_name() -> None:
 
 def test_salutation_uses_custom_name() -> None:
     assert salutation("Hermes") == "Salutations, Hermes."
+
+
+def test_salutation_trims_custom_name() -> None:
+    assert salutation("  Hermes  ") == "Salutations, Hermes."
+
+
+def test_salutation_uses_default_for_blank_name() -> None:
+    assert salutation("   ") == "Salutations, Daedalus."


### PR DESCRIPTION
## Summary
- add a private name normalization helper for greeting helpers
- route existing greeting helpers through the shared cleanup path
- cover trimming and blank-name fallback through public helper tests

## Validation
- python3 -m pip install -e .[test] --break-system-packages
- pytest

Closes #29