### PR TITLE
Add greeting CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,9 @@ requires-python = ">=3.10"
 readme = "README.md"
 dependencies = ["pytest"]
 
+[project.scripts]
+daedalus-greet = "daedalus_playground.cli:main"
+
 [tool.setuptools.packages.find]
 where = ["src"]
 

--- a/src/daedalus_playground/cli.py
+++ b/src/daedalus_playground/cli.py
@@ -1,0 +1,37 @@
+import argparse
+import sys
+from collections.abc import Callable, Sequence
+
+import daedalus_playground
+
+
+def _greeting_helpers() -> dict[str, Callable[[str], str]]:
+    helpers = {}
+    for name in daedalus_playground.__all__:
+        helper = getattr(daedalus_playground, name)
+        if callable(helper):
+            helpers[name] = helper
+    return helpers
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    helpers = _greeting_helpers()
+    parser = argparse.ArgumentParser(
+        prog="daedalus-greet",
+        description="Print a Daedalus greeting.",
+    )
+    parser.add_argument("kind", help="Greeting type to print.")
+    parser.add_argument("name", nargs="?", default="Daedalus")
+    args = parser.parse_args(argv)
+
+    helper = helpers.get(args.kind)
+    if helper is None:
+        available = ", ".join(sorted(helpers))
+        print(
+            f"Unknown greeting type: {args.kind}. Available types: {available}.",
+            file=sys.stderr,
+        )
+        return 2
+
+    print(helper(args.name))
+    return 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,29 @@
+from daedalus_playground.cli import main
+
+
+def test_cli_prints_selected_greeting(capsys) -> None:
+    exit_code = main(["greeting", "Hermes"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert captured.out == "Hello, Hermes!\n"
+    assert captured.err == ""
+
+
+def test_cli_prints_selected_salutation_with_default_name(capsys) -> None:
+    exit_code = main(["salutation"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert captured.out == "Salutations, Daedalus.\n"
+    assert captured.err == ""
+
+
+def test_cli_reports_unknown_greeting_type(capsys) -> None:
+    exit_code = main(["unknown", "Hermes"])
+
+    captured = capsys.readouterr()
+    assert exit_code != 0
+    assert captured.out == ""
+    assert "Unknown greeting type: unknown." in captured.err
+    assert "Available types: greeting, salutation." in captured.err


### PR DESCRIPTION
## Summary
- add the daedalus-greet console script
- dispatch CLI requests to currently exported greeting helpers
- cover greeting, salutation, and unknown-type CLI behavior

## Validation
- python3 -m pip install -e .[test] --break-system-packages
- pytest
- ~/.local/bin/daedalus-greet greeting Hermes
- ~/.local/bin/daedalus-greet salutation
- ~/.local/bin/daedalus-greet unknown Hermes

Closes #30