### PR TITLE
Add configurable greeting templates

### DIFF
--- a/src/daedalus_playground/__init__.py
+++ b/src/daedalus_playground/__init__.py
@@ -1,3 +1,3 @@
-from .greetings import greeting, salutation
+from .greetings import greeting, render_greeting_template, salutation
 
-__all__ = ["greeting", "salutation"]
+__all__ = ["greeting", "render_greeting_template", "salutation"]

--- a/src/daedalus_playground/cli.py
+++ b/src/daedalus_playground/cli.py
@@ -1,15 +1,27 @@
 import argparse
+import inspect
 import sys
 from collections.abc import Callable, Sequence
 
 import daedalus_playground
 
 
+def _is_simple_greeting_helper(helper: Callable[..., str]) -> bool:
+    signature = inspect.signature(helper)
+    positional_parameters = [
+        parameter
+        for parameter in signature.parameters.values()
+        if parameter.kind
+        in (parameter.POSITIONAL_ONLY, parameter.POSITIONAL_OR_KEYWORD)
+    ]
+    return len(positional_parameters) == 1
+
+
 def _greeting_helpers() -> dict[str, Callable[[str], str]]:
     helpers = {}
     for name in daedalus_playground.__all__:
         helper = getattr(daedalus_playground, name)
-        if callable(helper):
+        if callable(helper) and _is_simple_greeting_helper(helper):
             helpers[name] = helper
     return helpers
 

--- a/src/daedalus_playground/greetings.py
+++ b/src/daedalus_playground/greetings.py
@@ -1,15 +1,33 @@
+_GREETING_TEMPLATES = {
+    "friendly": "Hello, {name}!",
+    "formal": "Salutations, {name}.",
+    "farewell": "Goodbye, {name}.",
+}
+
+
 def _normalize_name(name: str) -> str:
     clean_name = name.strip()
     return clean_name or "Daedalus"
 
 
+def render_greeting_template(template_name: str, name: str = "Daedalus") -> str:
+    """Render a built-in greeting template with a normalized name."""
+    template = _GREETING_TEMPLATES.get(template_name)
+    if template is None:
+        available = ", ".join(sorted(_GREETING_TEMPLATES))
+        raise ValueError(
+            f"Unknown greeting template: {template_name}. "
+            f"Available templates: {available}."
+        )
+
+    return template.format(name=_normalize_name(name))
+
+
 def greeting(name: str = "Daedalus") -> str:
     """Return a predictable greeting for smoke tests."""
-    clean_name = _normalize_name(name)
-    return f"Hello, {clean_name}!"
+    return render_greeting_template("friendly", name)
 
 
 def salutation(name: str = "Daedalus") -> str:
     """Return the requested salutation helper."""
-    clean_name = _normalize_name(name)
-    return f"Salutations, {clean_name}."
+    return render_greeting_template("formal", name)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26,4 +26,5 @@ def test_cli_reports_unknown_greeting_type(capsys) -> None:
     assert exit_code != 0
     assert captured.out == ""
     assert "Unknown greeting type: unknown." in captured.err
-    assert "Available types: greeting, salutation." in captured.err
+    assert "greeting" in captured.err
+    assert "salutation" in captured.err

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26,5 +26,14 @@ def test_cli_reports_unknown_greeting_type(capsys) -> None:
     assert exit_code != 0
     assert captured.out == ""
     assert "Unknown greeting type: unknown." in captured.err
-    assert "greeting" in captured.err
-    assert "salutation" in captured.err
+    assert "Available types: greeting, salutation." in captured.err
+
+
+def test_cli_does_not_advertise_template_renderer_as_simple_greeting(capsys) -> None:
+    exit_code = main(["render_greeting_template", "friendly"])
+
+    captured = capsys.readouterr()
+    assert exit_code != 0
+    assert captured.out == ""
+    assert "Unknown greeting type: render_greeting_template." in captured.err
+    assert "Available types: greeting, salutation." in captured.err

--- a/tests/test_greeting_templates.py
+++ b/tests/test_greeting_templates.py
@@ -1,0 +1,25 @@
+import pytest
+
+from daedalus_playground import greeting, render_greeting_template, salutation
+
+
+def test_render_greeting_template_supports_built_in_templates() -> None:
+    assert render_greeting_template("friendly", "Hermes") == "Hello, Hermes!"
+    assert render_greeting_template("formal", "Hermes") == "Salutations, Hermes."
+    assert render_greeting_template("farewell", "Hermes") == "Goodbye, Hermes."
+
+
+def test_render_greeting_template_uses_default_for_blank_name() -> None:
+    assert render_greeting_template("farewell", "   ") == "Goodbye, Daedalus."
+
+
+def test_render_greeting_template_rejects_unknown_templates() -> None:
+    with pytest.raises(ValueError, match="Unknown greeting template: casual"):
+        render_greeting_template("casual", "Hermes")
+
+
+def test_existing_helpers_keep_their_outputs() -> None:
+    assert greeting("  Hermes  ") == "Hello, Hermes!"
+    assert greeting("   ") == "Hello, Daedalus!"
+    assert salutation("  Hermes  ") == "Salutations, Hermes."
+    assert salutation("   ") == "Salutations, Daedalus."


### PR DESCRIPTION
## Summary
- Add a built-in greeting template registry for friendly, formal, and farewell formats
- Add exported render_greeting_template helper with shared name normalization and clear unknown-template errors
- Keep greeting and salutation outputs compatible through focused regression coverage
- Filter CLI-discovered helpers to simple one-argument greeting helpers so render_greeting_template is not advertised as a CLI greeting type

## Validation
- python3 -m pip install -e .[test] --break-system-packages
- pytest