### PR TITLE
Add beacon token helper

### DIFF
--- a/src/daedalus_playground/beacon.py
+++ b/src/daedalus_playground/beacon.py
@@ -1,0 +1,3 @@
+def beacon_token(name: str = "Daedalus") -> str:
+    clean_name = name.strip() or "Daedalus"
+    return f"Beacon: {clean_name}"

--- a/tests/test_beacon.py
+++ b/tests/test_beacon.py
@@ -1,0 +1,13 @@
+from daedalus_playground.beacon import beacon_token
+
+
+def test_beacon_token_uses_default_name() -> None:
+    assert beacon_token() == "Beacon: Daedalus"
+
+
+def test_beacon_token_trims_custom_name() -> None:
+    assert beacon_token("  Hermes  ") == "Beacon: Hermes"
+
+
+def test_beacon_token_falls_back_for_blank_name() -> None:
+    assert beacon_token("   ") == "Beacon: Daedalus"


### PR DESCRIPTION
## Summary
- Add isolated beacon_token helper in src/daedalus_playground/beacon.py
- Cover default, trimmed custom, and blank-name fallback behavior in tests/test_beacon.py

## Validation
- python3 -m pip install -e .[test] --break-system-packages
- pytest