### PR TITLE
Add aurora token helper

### DIFF
--- a/src/daedalus_playground/aurora.py
+++ b/src/daedalus_playground/aurora.py
@@ -1,0 +1,4 @@
+def aurora_token(name: str = "Daedalus") -> str:
+    """Return the Aurora token for smoke tests."""
+    clean_name = name.strip()
+    return f"Aurora: {clean_name or 'Daedalus'}"

--- a/tests/test_aurora.py
+++ b/tests/test_aurora.py
@@ -1,0 +1,13 @@
+from daedalus_playground.aurora import aurora_token
+
+
+def test_aurora_token_uses_default_name() -> None:
+    assert aurora_token() == "Aurora: Daedalus"
+
+
+def test_aurora_token_trims_custom_name() -> None:
+    assert aurora_token("  Hermes  ") == "Aurora: Hermes"
+
+
+def test_aurora_token_uses_default_for_blank_name() -> None:
+    assert aurora_token("   ") == "Aurora: Daedalus"


### PR DESCRIPTION
## Summary
- add isolated daedalus_playground.aurora module with aurora_token
- trim custom names and fall back to Daedalus for blank input
- cover default, trimmed custom, and blank-name fallback behavior

## Validation
- python3 -m pip install -e .[test] --break-system-packages
- pytest