### PR TITLE
Add comet token helper

### DIFF
--- a/src/daedalus_playground/comet.py
+++ b/src/daedalus_playground/comet.py
@@ -1,0 +1,4 @@
+def comet_token(name: str = "Daedalus") -> str:
+    """Return a predictable comet token for smoke tests."""
+    clean_name = name.strip()
+    return f"Comet: {clean_name or 'Daedalus'}"

--- a/tests/test_comet.py
+++ b/tests/test_comet.py
@@ -1,0 +1,13 @@
+from daedalus_playground.comet import comet_token
+
+
+def test_comet_token_uses_default_name() -> None:
+    assert comet_token() == "Comet: Daedalus"
+
+
+def test_comet_token_trims_custom_name() -> None:
+    assert comet_token("  Hermes  ") == "Comet: Hermes"
+
+
+def test_comet_token_uses_default_for_blank_name() -> None:
+    assert comet_token("   ") == "Comet: Daedalus"


### PR DESCRIPTION
## Summary
- add isolated comet_token helper in src/daedalus_playground/comet.py
- add focused pytest coverage for default, trimmed custom, and blank-name fallback behavior

## Validation
- python3 -m pip install -e .[test] --break-system-packages
- pytest