### PR TITLE
Add drift token helper

### DIFF
--- a/src/daedalus_playground/drift.py
+++ b/src/daedalus_playground/drift.py
@@ -1,0 +1,3 @@
+def drift_token(name: str = "Daedalus") -> str:
+    clean_name = name.strip() or "Daedalus"
+    return f"Drift: {clean_name}"

--- a/tests/test_drift.py
+++ b/tests/test_drift.py
@@ -1,0 +1,13 @@
+from daedalus_playground.drift import drift_token
+
+
+def test_drift_token_uses_default_name() -> None:
+    assert drift_token() == "Drift: Daedalus"
+
+
+def test_drift_token_trims_custom_name() -> None:
+    assert drift_token("  Hermes  ") == "Drift: Hermes"
+
+
+def test_drift_token_falls_back_for_blank_name() -> None:
+    assert drift_token("   ") == "Drift: Daedalus"


### PR DESCRIPTION
## Summary
- Add isolated drift_token helper in src/daedalus_playground/drift.py
- Add focused tests for default, trimmed custom, and blank-name fallback behavior

## Validation
- python3 -m pip install -e .[test] --break-system-packages
- pytest