### PR TITLE
Add ember token helper

### DIFF
--- a/src/daedalus_playground/ember.py
+++ b/src/daedalus_playground/ember.py
@@ -1,0 +1,3 @@
+def ember_token(name: str = "Daedalus") -> str:
+    clean_name = name.strip() or "Daedalus"
+    return f"Ember: {clean_name}"

--- a/tests/test_ember.py
+++ b/tests/test_ember.py
@@ -1,0 +1,13 @@
+from daedalus_playground.ember import ember_token
+
+
+def test_ember_token_uses_default_name() -> None:
+    assert ember_token() == "Ember: Daedalus"
+
+
+def test_ember_token_trims_custom_name() -> None:
+    assert ember_token("  Hermes  ") == "Ember: Hermes"
+
+
+def test_ember_token_falls_back_for_blank_name() -> None:
+    assert ember_token("   ") == "Ember: Daedalus"


### PR DESCRIPTION
## Summary
- Add isolated ember_token helper returning the exact Ember token format
- Add focused pytest coverage for default, trimmed custom, and blank-name fallback behavior

## Validation
- python3 -m pip install -e '.[test]' --break-system-packages
- pytest