### PR TITLE
Add fable token helper

### DIFF
--- a/src/daedalus_playground/fable.py
+++ b/src/daedalus_playground/fable.py
@@ -1,0 +1,4 @@
+def fable_token(name: str = "Daedalus") -> str:
+    """Return the Fable token for smoke tests."""
+    clean_name = name.strip()
+    return f"Fable: {clean_name or 'Daedalus'}"

--- a/tests/test_fable.py
+++ b/tests/test_fable.py
@@ -1,0 +1,13 @@
+from daedalus_playground.fable import fable_token
+
+
+def test_fable_token_uses_default_name() -> None:
+    assert fable_token() == "Fable: Daedalus"
+
+
+def test_fable_token_trims_custom_name() -> None:
+    assert fable_token("  Hermes  ") == "Fable: Hermes"
+
+
+def test_fable_token_uses_default_for_blank_name() -> None:
+    assert fable_token("   ") == "Fable: Daedalus"


### PR DESCRIPTION
## Summary
- add isolated fable_token helper with whitespace trimming and blank-name fallback
- add focused pytest coverage for default, custom trimmed, and blank-name fallback behavior

## Validation
- python3 -m pip install -e .[test] --break-system-packages
- pytest

Closes #43