### PR TITLE
Add glimmer token helper

### DIFF
--- a/src/daedalus_playground/glimmer.py
+++ b/src/daedalus_playground/glimmer.py
@@ -1,0 +1,4 @@
+def glimmer_token(name: str = "Daedalus") -> str:
+    """Return the Glimmer token for smoke tests."""
+    clean_name = name.strip()
+    return f"Glimmer: {clean_name or 'Daedalus'}"

--- a/tests/test_glimmer.py
+++ b/tests/test_glimmer.py
@@ -1,0 +1,13 @@
+from daedalus_playground.glimmer import glimmer_token
+
+
+def test_glimmer_token_uses_default_name() -> None:
+    assert glimmer_token() == "Glimmer: Daedalus"
+
+
+def test_glimmer_token_trims_custom_name() -> None:
+    assert glimmer_token("  Hermes  ") == "Glimmer: Hermes"
+
+
+def test_glimmer_token_uses_default_for_blank_name() -> None:
+    assert glimmer_token("   ") == "Glimmer: Daedalus"


### PR DESCRIPTION
## Summary
- add isolated glimmer_token smoke helper
- cover default, trimmed custom, and blank-name fallback behavior

## Validation
- python3 -m pip install -e .[test] --break-system-packages
- pytest
- git diff --check

Closes #44