### PR TITLE
Add ion token helper

### DIFF
--- a/src/daedalus_playground/ion.py
+++ b/src/daedalus_playground/ion.py
@@ -1,0 +1,4 @@
+def ion_token(name: str = "Daedalus") -> str:
+    """Return the Ion token for smoke tests."""
+    clean_name = name.strip()
+    return f"Ion: {clean_name or 'Daedalus'}"

--- a/tests/test_ion.py
+++ b/tests/test_ion.py
@@ -1,0 +1,13 @@
+from daedalus_playground.ion import ion_token
+
+
+def test_ion_token_uses_default_name() -> None:
+    assert ion_token() == "Ion: Daedalus"
+
+
+def test_ion_token_trims_custom_name() -> None:
+    assert ion_token("  Hermes  ") == "Ion: Hermes"
+
+
+def test_ion_token_uses_default_for_blank_name() -> None:
+    assert ion_token("   ") == "Ion: Daedalus"


### PR DESCRIPTION
## Summary
- Add isolated ion_token helper in src/daedalus_playground/ion.py
- Add focused pytest coverage for default, trimmed custom, and blank-name fallback behavior

## Validation
- python3 -m pip install -e .[test] --break-system-packages
- pytest

Closes #46