### PR TITLE
Add harbor token helper

### DIFF
--- a/src/daedalus_playground/harbor.py
+++ b/src/daedalus_playground/harbor.py
@@ -1,0 +1,4 @@
+def harbor_token(name: str = "Daedalus") -> str:
+    """Return the Harbor token for smoke tests."""
+    clean_name = name.strip()
+    return f"Harbor: {clean_name or 'Daedalus'}"

--- a/tests/test_harbor.py
+++ b/tests/test_harbor.py
@@ -1,0 +1,13 @@
+from daedalus_playground.harbor import harbor_token
+
+
+def test_harbor_token_uses_default_name() -> None:
+    assert harbor_token() == "Harbor: Daedalus"
+
+
+def test_harbor_token_trims_custom_name() -> None:
+    assert harbor_token("  Hermes  ") == "Harbor: Hermes"
+
+
+def test_harbor_token_uses_default_for_blank_name() -> None:
+    assert harbor_token("   ") == "Harbor: Daedalus"


### PR DESCRIPTION
## Summary

- Add isolated harbor_token helper with whitespace trimming and blank-name fallback.

- Add focused harbor pytest coverage for default, trimmed custom, and blank-name behavior.
## Validation

- python3 -m pip install -e .[test] --break-system-packages
- pytest

