### PR TITLE
Add juno token helper

### DIFF
--- a/src/daedalus_playground/juno.py
+++ b/src/daedalus_playground/juno.py
@@ -1,0 +1,4 @@
+def juno_token(name: str = "Daedalus") -> str:
+    """Return the Juno token for smoke tests."""
+    clean_name = name.strip()
+    return f"Juno: {clean_name or 'Daedalus'}"

--- a/tests/test_juno.py
+++ b/tests/test_juno.py
@@ -1,0 +1,13 @@
+from daedalus_playground.juno import juno_token
+
+
+def test_juno_token_uses_default_name() -> None:
+    assert juno_token() == "Juno: Daedalus"
+
+
+def test_juno_token_trims_custom_name() -> None:
+    assert juno_token("  Hermes  ") == "Juno: Hermes"
+
+
+def test_juno_token_uses_default_for_blank_name() -> None:
+    assert juno_token("   ") == "Juno: Daedalus"


### PR DESCRIPTION
## Summary
- add isolated juno_token helper with whitespace trimming and blank-name fallback
- add focused tests for default, trimmed custom, and blank-name behavior

## Validation
- python3 -m pip install -e .[test] --break-system-packages
- pytest
- git diff --check