### PR TITLE
Add kappa token helper

### DIFF
--- a/src/playground/kappa.py
+++ b/src/playground/kappa.py
@@ -1,0 +1,4 @@
+def kappa_token(name: str = "Sprints") -> str:
+    """Return the Kappa token for smoke tests."""
+    clean_name = name.strip()
+    return f"Kappa: {clean_name or 'Sprints'}"

--- a/tests/test_kappa.py
+++ b/tests/test_kappa.py
@@ -1,0 +1,13 @@
+from playground.kappa import kappa_token
+
+
+def test_kappa_token_uses_default_name() -> None:
+    assert kappa_token() == "Kappa: Sprints"
+
+
+def test_kappa_token_trims_custom_name() -> None:
+    assert kappa_token("  Hermes  ") == "Kappa: Hermes"
+
+
+def test_kappa_token_uses_default_for_blank_name() -> None:
+    assert kappa_token("   ") == "Kappa: Sprints"


### PR DESCRIPTION
## Summary
- add isolated `kappa_token` helper with trim and blank-name fallback behavior
- add focused pytest coverage for default, custom trimmed, and blank input cases

## Validation
- pytest

Closes #58