### PR TITLE
Add nova token helper

### DIFF
--- a/src/playground/nova.py
+++ b/src/playground/nova.py
@@ -1,0 +1,3 @@
+def nova_token(name: str = "Sprints") -> str:
+    clean_name = name.strip() or "Sprints"
+    return f"Nova: {clean_name}"

--- a/tests/test_nova.py
+++ b/tests/test_nova.py
@@ -1,0 +1,13 @@
+from playground.nova import nova_token
+
+
+def test_nova_token_uses_default_name() -> None:
+    assert nova_token() == "Nova: Sprints"
+
+
+def test_nova_token_trims_custom_name() -> None:
+    assert nova_token("  Hermes  ") == "Nova: Hermes"
+
+
+def test_nova_token_falls_back_for_blank_name() -> None:
+    assert nova_token("   ") == "Nova: Sprints"


### PR DESCRIPTION
## Summary
- Add isolated nova token helper with whitespace trimming and blank-name fallback
- Add focused tests for default, custom trimmed, and blank-name behavior

## Validation
- pytest

Closes #61