### PR TITLE
Add lumen token helper

### DIFF
--- a/src/playground/lumen.py
+++ b/src/playground/lumen.py
@@ -1,0 +1,4 @@
+def lumen_token(name: str = "Sprints") -> str:
+    """Return the Lumen token for smoke tests."""
+    clean_name = name.strip()
+    return f"Lumen: {clean_name or 'Sprints'}"

--- a/tests/test_lumen.py
+++ b/tests/test_lumen.py
@@ -1,0 +1,13 @@
+from playground.lumen import lumen_token
+
+
+def test_lumen_token_uses_default_name() -> None:
+    assert lumen_token() == "Lumen: Sprints"
+
+
+def test_lumen_token_trims_custom_name() -> None:
+    assert lumen_token("  Hermes  ") == "Lumen: Hermes"
+
+
+def test_lumen_token_uses_default_for_blank_name() -> None:
+    assert lumen_token("   ") == "Lumen: Sprints"


### PR DESCRIPTION
## Summary
- Add isolated playground.lumen.lumen_token helper
- Cover default, trimmed custom, and blank-name fallback behavior

## Validation
- pytest
- uv pip install --python /tmp/playground-issue59-venv/bin/python -e .[test]
- /tmp/playground-issue59-venv/bin/python -m pytest

Closes #59