### PR TITLE
Add matrix token helper

### DIFF
--- a/src/playground/matrix.py
+++ b/src/playground/matrix.py
@@ -1,0 +1,4 @@
+def matrix_token(name: str = "Sprints") -> str:
+    """Return the Matrix token for smoke tests."""
+    clean_name = name.strip()
+    return f"Matrix: {clean_name or 'Sprints'}"

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -1,0 +1,13 @@
+from playground.matrix import matrix_token
+
+
+def test_matrix_token_uses_default_name() -> None:
+    assert matrix_token() == "Matrix: Sprints"
+
+
+def test_matrix_token_trims_custom_name() -> None:
+    assert matrix_token("  Hermes  ") == "Matrix: Hermes"
+
+
+def test_matrix_token_uses_default_for_blank_name() -> None:
+    assert matrix_token("   ") == "Matrix: Sprints"


### PR DESCRIPTION
## Summary
- add isolated matrix token helper
- cover default, trimmed custom, and blank-name fallback behavior

## Validation
- pytest tests/test_matrix.py
- pytest

Closes #60