### PR TITLE
Add orbit token helper

### DIFF
--- a/src/playground/orbit.py
+++ b/src/playground/orbit.py
@@ -1,0 +1,3 @@
+def orbit_token(name: str = "Sprints") -> str:
+    clean_name = name.strip() or "Sprints"
+    return f"Orbit: {clean_name}"

--- a/tests/test_orbit.py
+++ b/tests/test_orbit.py
@@ -1,0 +1,13 @@
+from playground.orbit import orbit_token
+
+
+def test_orbit_token_uses_default_name() -> None:
+    assert orbit_token() == "Orbit: Sprints"
+
+
+def test_orbit_token_trims_custom_name() -> None:
+    assert orbit_token("  Hermes  ") == "Orbit: Hermes"
+
+
+def test_orbit_token_falls_back_for_blank_name() -> None:
+    assert orbit_token("   ") == "Orbit: Sprints"


### PR DESCRIPTION
## Summary
- Add isolated orbit_token helper with trimmed-name fallback behavior
- Add focused coverage for default, custom trimmed, and blank-name cases

## Validation
- pytest tests/test_orbit.py
- pytest
- python3 -m pip install --target /tmp/playground-github62-pip -e .[test]
- PYTHONPATH=/tmp/playground-github62-pip python3 -m pytest

Note: direct python3 -m pip install -e .[test] is blocked on this host by PEP 668 externally-managed-environment, so validation used an isolated /tmp target install.