### PR TITLE
Add prism token helper

### DIFF
--- a/src/playground/prism.py
+++ b/src/playground/prism.py
@@ -1,0 +1,4 @@
+def prism_token(name: str = "Sprints") -> str:
+    """Return the Prism token for smoke tests."""
+    clean_name = name.strip()
+    return f"Prism: {clean_name or 'Sprints'}"

--- a/tests/test_prism.py
+++ b/tests/test_prism.py
@@ -1,0 +1,13 @@
+from playground.prism import prism_token
+
+
+def test_prism_token_uses_default_name() -> None:
+    assert prism_token() == "Prism: Sprints"
+
+
+def test_prism_token_trims_custom_name() -> None:
+    assert prism_token("  Hermes  ") == "Prism: Hermes"
+
+
+def test_prism_token_uses_default_for_blank_name() -> None:
+    assert prism_token("   ") == "Prism: Sprints"


### PR DESCRIPTION
## Summary
- Add isolated `prism_token` helper with whitespace trimming and blank-name fallback
- Add focused pytest coverage for default, custom trimmed, and blank-name behavior

## Verification
- `pytest tests/test_prism.py`
- `pytest`
- `PYTHONPATH=/tmp/playground-github63-pip python3 -m pytest`

Note: direct `python3 -m pip install -e .[test]` was blocked by the system Python PEP 668 guard; editable install validation used an isolated `/tmp` target instead.