### PR TITLE
Add quartz token helper

### DIFF
--- a/src/playground/quartz.py
+++ b/src/playground/quartz.py
@@ -1,0 +1,4 @@
+def quartz_token(name: str = "Sprints") -> str:
+    """Return the Quartz token for smoke tests."""
+    clean_name = name.strip()
+    return f"Quartz: {clean_name or 'Sprints'}"

--- a/tests/test_quartz.py
+++ b/tests/test_quartz.py
@@ -1,0 +1,13 @@
+from playground.quartz import quartz_token
+
+
+def test_quartz_token_uses_default_name() -> None:
+    assert quartz_token() == "Quartz: Sprints"
+
+
+def test_quartz_token_trims_custom_name() -> None:
+    assert quartz_token("  Hermes  ") == "Quartz: Hermes"
+
+
+def test_quartz_token_uses_default_for_blank_name() -> None:
+    assert quartz_token("   ") == "Quartz: Sprints"


### PR DESCRIPTION
## Summary
- Add isolated quartz_token helper with whitespace trimming and blank-name fallback
- Add focused pytest coverage for default, custom trimmed, and blank-name fallback behavior

## Validation
- pytest tests/test_quartz.py
- pytest

Closes #64