### PR TITLE
Add ripple token helper

### DIFF
--- a/src/playground/ripple.py
+++ b/src/playground/ripple.py
@@ -1,0 +1,4 @@
+def ripple_token(name: str = "Sprints") -> str:
+    """Return the Ripple token for smoke tests."""
+    clean_name = name.strip()
+    return f"Ripple: {clean_name or 'Sprints'}"

--- a/tests/test_ripple.py
+++ b/tests/test_ripple.py
@@ -1,0 +1,13 @@
+from playground.ripple import ripple_token
+
+
+def test_ripple_token_uses_default_name() -> None:
+    assert ripple_token() == "Ripple: Sprints"
+
+
+def test_ripple_token_trims_custom_name() -> None:
+    assert ripple_token("  Hermes  ") == "Ripple: Hermes"
+
+
+def test_ripple_token_uses_default_for_blank_name() -> None:
+    assert ripple_token("   ") == "Ripple: Sprints"


### PR DESCRIPTION
## Summary

- Add isolated ripple_token helper with whitespace trimming and blank-name fallback.
- Add focused pytest coverage for default, trimmed custom, and blank input behavior.

## Validation
- pytest tests/test_ripple.py
- pytest
- uv pip install --python /tmp/playground-github65-uvvenv/bin/python -e '.[test]' && /tmp/playground-github65-uvvenv/bin/python -m pytest

## Notes
- Direct python3 -m pip install -e .[test] was blocked by the system Python PEP 668 externally-managed-environment guard.
- python3 -m venv was unavailable because ensurepip is not installed, so install validation used an external uv-created venv.
