### PR TITLE
Add sol token helper

### DIFF
--- a/src/playground/sol.py
+++ b/src/playground/sol.py
@@ -1,0 +1,4 @@
+def sol_token(name: str = "Sprints") -> str:
+    """Return the Sol token for smoke tests."""
+    clean_name = name.strip()
+    return f"Sol: {clean_name or 'Sprints'}"

--- a/tests/test_sol.py
+++ b/tests/test_sol.py
@@ -1,0 +1,13 @@
+from playground.sol import sol_token
+
+
+def test_sol_token_uses_default_name() -> None:
+    assert sol_token() == "Sol: Sprints"
+
+
+def test_sol_token_trims_custom_name() -> None:
+    assert sol_token("  Hermes  ") == "Sol: Hermes"
+
+
+def test_sol_token_uses_default_for_blank_name() -> None:
+    assert sol_token("   ") == "Sol: Sprints"


### PR DESCRIPTION
## Summary
- Add isolated sol_token helper with whitespace trimming and blank-name fallback
- Add focused pytest coverage for default, custom trimmed, and blank input behavior

## Verification
- pytest tests/test_sol.py
- pytest
- uv pip install --python /tmp/playground-github66-uvvenv/bin/python -e '.[test]'
- /tmp/playground-github66-uvvenv/bin/python -m pytest

Closes #66