### PR TITLE
Add tide token helper

### DIFF
--- a/src/playground/tide.py
+++ b/src/playground/tide.py
@@ -1,0 +1,4 @@
+def tide_token(name: str = "Sprints") -> str:
+    """Return the Tide token for smoke tests."""
+    clean_name = name.strip()
+    return f"Tide: {clean_name or 'Sprints'}"

--- a/tests/test_tide.py
+++ b/tests/test_tide.py
@@ -1,0 +1,13 @@
+from playground.tide import tide_token
+
+
+def test_tide_token_uses_default_name() -> None:
+    assert tide_token() == "Tide: Sprints"
+
+
+def test_tide_token_trims_custom_name() -> None:
+    assert tide_token("  Hermes  ") == "Tide: Hermes"
+
+
+def test_tide_token_uses_default_for_blank_name() -> None:
+    assert tide_token("   ") == "Tide: Sprints"


### PR DESCRIPTION
## Summary
- Add isolated tide_token helper with whitespace trimming and Sprints fallback
- Add focused tests for default, trimmed custom name, and blank input behavior

## Validation
- pytest tests/test_tide.py
- pytest
- uv pip install --python /tmp/playground-github67-uvvenv-208812/bin/python -e '.[test]'
- /tmp/playground-github67-uvvenv-208812/bin/python -m pytest

Note: direct python3 -m pip install -e '.[test]' is blocked by the system Python PEP 668 externally-managed-environment guard, so install validation used an external uv-created venv.