### PR TITLE
Add umbra token helper

### DIFF
--- a/src/playground/umbra.py
+++ b/src/playground/umbra.py
@@ -1,0 +1,4 @@
+def umbra_token(name: str = "Sprints") -> str:
+    """Return the Umbra token for smoke tests."""
+    clean_name = name.strip()
+    return f"Umbra: {clean_name or 'Sprints'}"

--- a/tests/test_umbra.py
+++ b/tests/test_umbra.py
@@ -1,0 +1,13 @@
+from playground.umbra import umbra_token
+
+
+def test_umbra_token_uses_default_name() -> None:
+    assert umbra_token() == "Umbra: Sprints"
+
+
+def test_umbra_token_trims_custom_name() -> None:
+    assert umbra_token("  Hermes  ") == "Umbra: Hermes"
+
+
+def test_umbra_token_uses_default_for_blank_name() -> None:
+    assert umbra_token("   ") == "Umbra: Sprints"


### PR DESCRIPTION
## Summary
- Add isolated umbra_token helper with whitespace trimming and blank-name fallback
- Add focused pytest coverage for default, trimmed custom, and blank name behavior

## Validation
- pytest tests/test_umbra.py
- pytest
- uv pip install --python /tmp/playground-github68-uvvenv/bin/python -e '.[test]'
- /tmp/playground-github68-uvvenv/bin/python -m pytest

Note: direct python3 -m pip install -e '.[test]' was blocked by the system Python PEP 668 externally-managed-environment guard, so install validation used an external uv-created venv.