### PR TITLE
Add vector token helper

### DIFF
--- a/src/playground/vector.py
+++ b/src/playground/vector.py
@@ -1,0 +1,4 @@
+def vector_token(name: str = "Sprints") -> str:
+    """Return the Vector token for smoke tests."""
+    clean_name = name.strip()
+    return f"Vector: {clean_name or 'Sprints'}"

--- a/tests/test_vector.py
+++ b/tests/test_vector.py
@@ -1,0 +1,13 @@
+from playground.vector import vector_token
+
+
+def test_vector_token_uses_default_name() -> None:
+    assert vector_token() == "Vector: Sprints"
+
+
+def test_vector_token_trims_custom_name() -> None:
+    assert vector_token("  Hermes  ") == "Vector: Hermes"
+
+
+def test_vector_token_uses_default_for_blank_name() -> None:
+    assert vector_token("   ") == "Vector: Sprints"


### PR DESCRIPTION
## Summary
- add isolated vector_token helper with whitespace trimming and blank-name fallback
- add focused pytest coverage for default, trimmed custom, and blank-name behavior

## Validation
- pytest tests/test_vector.py
- pytest
- uv pip install --python /tmp/playground-github69-uvvenv/bin/python -e '.[test]'
- /tmp/playground-github69-uvvenv/bin/python -m pytest

Closes #69