### PR TITLE
Add willow token helper

### DIFF
--- a/src/playground/willow.py
+++ b/src/playground/willow.py
@@ -1,0 +1,4 @@
+def willow_token(name: str = "Sprints") -> str:
+    """Return the Willow token for smoke tests."""
+    clean_name = name.strip()
+    return f"Willow: {clean_name or 'Sprints'}"

--- a/tests/test_willow.py
+++ b/tests/test_willow.py
@@ -1,0 +1,13 @@
+from playground.willow import willow_token
+
+
+def test_willow_token_uses_default_name() -> None:
+    assert willow_token() == "Willow: Sprints"
+
+
+def test_willow_token_trims_custom_name() -> None:
+    assert willow_token("  Hermes  ") == "Willow: Hermes"
+
+
+def test_willow_token_uses_default_for_blank_name() -> None:
+    assert willow_token("   ") == "Willow: Sprints"


### PR DESCRIPTION
## Summary

- Add isolated willow_token helper with trimming and blank-name fallback.
- Add focused willow tests for default, custom trimmed, and blank-name behavior.
Closes #70

## Validation
- pytest tests/test_willow.py
- pytest
- uv pip install --python /tmp/playground-github70-uvvenv-211936/bin/python -e '.[test]' && /tmp/playground-github70-uvvenv-211936/bin/python -m pytest
