### PR TITLE
Add xenon token helper

### DIFF
--- a/src/playground/xenon.py
+++ b/src/playground/xenon.py
@@ -1,0 +1,4 @@
+def xenon_token(name: str = "Sprints") -> str:
+    """Return the Xenon token for smoke tests."""
+    clean_name = name.strip()
+    return f"Xenon: {clean_name or 'Sprints'}"

--- a/tests/test_xenon.py
+++ b/tests/test_xenon.py
@@ -1,0 +1,13 @@
+from playground.xenon import xenon_token
+
+
+def test_xenon_token_uses_default_name() -> None:
+    assert xenon_token() == "Xenon: Sprints"
+
+
+def test_xenon_token_trims_custom_name() -> None:
+    assert xenon_token("  Hermes  ") == "Xenon: Hermes"
+
+
+def test_xenon_token_uses_default_for_blank_name() -> None:
+    assert xenon_token("   ") == "Xenon: Sprints"


### PR DESCRIPTION
## Summary
- Add isolated xenon_token helper with trimming and blank-name fallback
- Add focused pytest coverage for default, trimmed custom, and blank input behavior

## Validation
- pytest tests/test_xenon.py
- pytest

Closes #71