### PR TITLE
Add yonder token helper

### DIFF
--- a/src/playground/yonder.py
+++ b/src/playground/yonder.py
@@ -1,0 +1,4 @@
+def yonder_token(name: str = "Sprints") -> str:
+    """Return the Yonder token for smoke tests."""
+    clean_name = name.strip()
+    return f"Yonder: {clean_name or 'Sprints'}"

--- a/tests/test_yonder.py
+++ b/tests/test_yonder.py
@@ -1,0 +1,13 @@
+from playground.yonder import yonder_token
+
+
+def test_yonder_token_uses_default_name() -> None:
+    assert yonder_token() == "Yonder: Sprints"
+
+
+def test_yonder_token_trims_custom_name() -> None:
+    assert yonder_token("  Hermes  ") == "Yonder: Hermes"
+
+
+def test_yonder_token_uses_default_for_blank_name() -> None:
+    assert yonder_token("   ") == "Yonder: Sprints"


### PR DESCRIPTION
## Summary
- Add isolated yonder_token helper with whitespace trimming and blank-name fallback
- Add focused pytest coverage for default, custom trimmed, and blank-name fallback behavior

## Validation
- pytest tests/test_yonder.py
- pytest
- uv pip install --python /tmp/playground-github72-uvvenv/bin/python -e '.[test]'
- /tmp/playground-github72-uvvenv/bin/python -m pytest

Notes: direct python3 -m pip install -e '.[test]' was blocked by the system Python PEP 668 externally-managed-environment guard, so editable-install validation used an external uv-created venv. uv warned that the package has no extra named test; pyproject.toml was not edited per issue scope.