### PR TITLE
Add atlas path classifier

### DIFF
--- a/src/playground/atlas.py
+++ b/src/playground/atlas.py
@@ -1,0 +1,32 @@
+def classify_path(value: str) -> dict[str, object]:
+    """Classify a POSIX-style path for smoke tests."""
+    clean_value = value.strip()
+
+    if clean_value == "":
+        return {
+            "kind": "empty",
+            "depth": 0,
+            "basename": "",
+            "extension": "",
+            "segments": [],
+        }
+
+    kind = "absolute" if clean_value.startswith("/") else "relative"
+    segments = [segment for segment in clean_value.split("/") if segment]
+    basename = segments[-1] if segments else ""
+    extension = _extension_for(basename)
+
+    return {
+        "kind": kind,
+        "depth": len(segments),
+        "basename": basename,
+        "extension": extension,
+        "segments": segments,
+    }
+
+
+def _extension_for(basename: str) -> str:
+    stem, separator, extension = basename.rpartition(".")
+    if separator and stem:
+        return extension
+    return ""

--- a/tests/test_atlas.py
+++ b/tests/test_atlas.py
@@ -1,0 +1,51 @@
+from playground.atlas import classify_path
+
+
+def test_classify_path_handles_empty_input() -> None:
+    assert classify_path("   ") == {
+        "kind": "empty",
+        "depth": 0,
+        "basename": "",
+        "extension": "",
+        "segments": [],
+    }
+
+
+def test_classify_path_handles_absolute_path() -> None:
+    assert classify_path(" /srv/app/config ") == {
+        "kind": "absolute",
+        "depth": 3,
+        "basename": "config",
+        "extension": "",
+        "segments": ["srv", "app", "config"],
+    }
+
+
+def test_classify_path_handles_relative_path() -> None:
+    assert classify_path("docs/readme") == {
+        "kind": "relative",
+        "depth": 2,
+        "basename": "readme",
+        "extension": "",
+        "segments": ["docs", "readme"],
+    }
+
+
+def test_classify_path_collapses_repeated_slashes_for_segments() -> None:
+    assert classify_path("//var///log/app/") == {
+        "kind": "absolute",
+        "depth": 3,
+        "basename": "app",
+        "extension": "",
+        "segments": ["var", "log", "app"],
+    }
+
+
+def test_classify_path_extracts_extension_without_dot() -> None:
+    assert classify_path("reports/summary.final.txt") == {
+        "kind": "relative",
+        "depth": 2,
+        "basename": "summary.final.txt",
+        "extension": "txt",
+        "segments": ["reports", "summary.final.txt"],
+    }


### PR DESCRIPTION
## Summary
- Add isolated atlas path classifier for POSIX-style path inputs
- Normalize surrounding whitespace, preserve absolute classification, and collapse repeated slashes for segments
- Cover empty, absolute, relative, repeated slash, and extension cases

## Validation
- pytest tests/test_atlas.py
- pytest
- python3 -m pip install -e '.[test]' (blocked by system Python PEP 668 externally-managed-environment)
- python3 -m pip install --target /tmp/playground-github88-pip -e '.[test]'
- PYTHONPATH=/tmp/playground-github88-pip python3 -m pytest