### PR TITLE
Add equinox time window helper

### DIFF
--- a/src/playground/equinox.py
+++ b/src/playground/equinox.py
@@ -1,0 +1,24 @@
+def _validate_hour(hour: int) -> None:
+    if hour < 0 or hour > 23:
+        raise ValueError("hour must be between 0 and 23")
+
+
+def window_label(hour: int) -> str:
+    """Return the equinox time window label for an hour of day."""
+    _validate_hour(hour)
+
+    if hour <= 5:
+        return "night"
+    if hour <= 11:
+        return "morning"
+    if hour <= 16:
+        return "afternoon"
+    if hour <= 20:
+        return "evening"
+    return "late"
+
+
+def is_business_hour(hour: int) -> bool:
+    """Return whether the hour is within the equinox business window."""
+    _validate_hour(hour)
+    return 9 <= hour <= 16

--- a/tests/test_equinox.py
+++ b/tests/test_equinox.py
@@ -1,0 +1,47 @@
+import pytest
+
+from playground.equinox import is_business_hour, window_label
+
+
+@pytest.mark.parametrize(
+    ("hour", "label"),
+    [
+        (0, "night"),
+        (5, "night"),
+        (6, "morning"),
+        (11, "morning"),
+        (12, "afternoon"),
+        (16, "afternoon"),
+        (17, "evening"),
+        (20, "evening"),
+        (21, "late"),
+        (23, "late"),
+    ],
+)
+def test_window_label_boundaries(hour: int, label: str) -> None:
+    assert window_label(hour) == label
+
+
+@pytest.mark.parametrize(
+    ("hour", "expected"),
+    [
+        (8, False),
+        (9, True),
+        (16, True),
+        (17, False),
+    ],
+)
+def test_is_business_hour_boundaries(hour: int, expected: bool) -> None:
+    assert is_business_hour(hour) is expected
+
+
+@pytest.mark.parametrize("hour", [-1, 24])
+def test_window_label_rejects_invalid_hours(hour: int) -> None:
+    with pytest.raises(ValueError):
+        window_label(hour)
+
+
+@pytest.mark.parametrize("hour", [-1, 24])
+def test_is_business_hour_rejects_invalid_hours(hour: int) -> None:
+    with pytest.raises(ValueError):
+        is_business_hour(hour)


### PR DESCRIPTION
## Summary
- add isolated equinox time window labeling helper
- add business-hour validation and boundary coverage

## Verification
- pytest tests/test_equinox.py
- pytest
- uv pip install --python /tmp/playground-github92-uvvenv/bin/python -e '.[test]' && /tmp/playground-github92-uvvenv/bin/python -m pytest

Closes #92