### PR TITLE
Add cipher redaction helper

### DIFF
--- a/src/playground/cipher.py
+++ b/src/playground/cipher.py
@@ -1,0 +1,12 @@
+import re
+
+
+_SECRET_ASSIGNMENT = re.compile(
+    r"(?P<prefix>\b(?:token|api_key)\s*=\s*|\bsecret\s*:\s*)[^\s,;]+",
+    re.IGNORECASE,
+)
+
+
+def redact_secrets(text: str) -> str:
+    """Redact known secret assignment values from text."""
+    return _SECRET_ASSIGNMENT.sub(r"\g<prefix>[REDACTED]", text)

--- a/tests/test_cipher.py
+++ b/tests/test_cipher.py
@@ -1,0 +1,34 @@
+from playground.cipher import redact_secrets
+
+
+def test_redacts_token_assignment() -> None:
+    assert redact_secrets("token=abc123") == "token=[REDACTED]"
+
+
+def test_redacts_api_key_assignment_case_insensitively() -> None:
+    assert redact_secrets("API_KEY=secret-value") == "API_KEY=[REDACTED]"
+
+
+def test_redacts_secret_colon_assignment() -> None:
+    assert redact_secrets("secret: hunter2") == "secret: [REDACTED]"
+
+
+def test_redacts_mixed_text_without_changing_other_content() -> None:
+    text = "start token=one middle api_key=two end secret: three"
+    assert (
+        redact_secrets(text)
+        == "start token=[REDACTED] middle api_key=[REDACTED] end secret: [REDACTED]"
+    )
+
+
+def test_preserves_punctuation_boundaries() -> None:
+    text = "token=one, api_key=two; secret: three done"
+    assert (
+        redact_secrets(text)
+        == "token=[REDACTED], api_key=[REDACTED]; secret: [REDACTED] done"
+    )
+
+
+def test_leaves_non_secret_text_unchanged() -> None:
+    text = "username=ada password: open-sesame note tokenless"
+    assert redact_secrets(text) == text


### PR DESCRIPTION
## Summary
- add isolated cipher.redact_secrets helper for token, api_key, and secret assignments
- preserve original key/separator while replacing matched values with [REDACTED]
- cover secret forms, mixed text, punctuation boundaries, and non-secret text

## Validation
- pytest tests/test_cipher.py
- pytest
- uv pip install --python /tmp/playground-github90-uvvenv/bin/python -e '.[test]' && /tmp/playground-github90-uvvenv/bin/python -m pytest

Note: direct python3 -m pip install -e '.[test]' is blocked by the system Python PEP 668 externally-managed-environment guard, so install validation used an external uv-created venv.