### PR TITLE
Add dapple table summarizer

### DIFF
--- a/src/playground/dapple.py
+++ b/src/playground/dapple.py
@@ -1,0 +1,30 @@
+"""Small row summarization helper for table-like dictionaries."""
+
+
+def summarize_rows(rows: list[dict[str, object]], key: str) -> dict[str, object]:
+    """Summarize non-missing values for one key across row dictionaries."""
+    missing = 0
+    unique_values: list[object] = []
+    first: object | None = None
+    last: object | None = None
+
+    for row in rows:
+        value = row.get(key)
+        if value is None:
+            missing += 1
+            continue
+
+        if first is None:
+            first = value
+        last = value
+
+        if not any(value == existing for existing in unique_values):
+            unique_values.append(value)
+
+    return {
+        "count": len(rows),
+        "missing": missing,
+        "unique": len(unique_values),
+        "first": first,
+        "last": last,
+    }

--- a/tests/test_dapple.py
+++ b/tests/test_dapple.py
@@ -1,0 +1,58 @@
+from copy import deepcopy
+
+from playground.dapple import summarize_rows
+
+
+def test_summarize_rows_empty_rows() -> None:
+    assert summarize_rows([], "name") == {
+        "count": 0,
+        "missing": 0,
+        "unique": 0,
+        "first": None,
+        "last": None,
+    }
+
+
+def test_summarize_rows_counts_absent_and_none_as_missing() -> None:
+    rows = [{"status": "ready"}, {}, {"status": None}, {"status": "done"}]
+
+    summary = summarize_rows(rows, "status")
+
+    assert summary["count"] == 4
+    assert summary["missing"] == 2
+
+
+def test_summarize_rows_counts_unique_non_missing_values_by_equality() -> None:
+    rows = [
+        {"tags": ["alpha", "beta"]},
+        {"tags": ["alpha", "beta"]},
+        {"tags": ["beta"]},
+    ]
+
+    summary = summarize_rows(rows, "tags")
+
+    assert summary["unique"] == 2
+
+
+def test_summarize_rows_tracks_first_and_last_non_missing_values() -> None:
+    rows = [
+        {},
+        {"score": None},
+        {"score": 10},
+        {"score": 20},
+        {"score": 10},
+    ]
+
+    summary = summarize_rows(rows, "score")
+
+    assert summary["first"] == 10
+    assert summary["last"] == 10
+
+
+def test_summarize_rows_does_not_mutate_input_rows() -> None:
+    rows = [{"value": ["same"]}, {"value": None}, {}]
+    original = deepcopy(rows)
+
+    summarize_rows(rows, "value")
+
+    assert rows == original


### PR DESCRIPTION
## Summary
- Add summarize_rows for table-like dictionaries keyed by a requested column.
- Count total rows, missing values, distinct non-missing values by Python equality, and first/last non-missing values.
- Add focused pytest coverage for empty input, missing values, unique counting, first/last, and input immutability.

## Validation
- pytest tests/test_dapple.py
- pytest
- uv pip install --python /tmp/playground-github91-uvvenv/bin/python -e '.[test]'\n- /tmp/playground-github91-uvvenv/bin/python -m pytest\n\nNote: direct python3 -m pip install -e '.[test]' was blocked by the system Python PEP 668 externally-managed-environment guard, so install validation used a temporary external uv venv.