### PR TITLE
Add brio priority parser

### DIFF
--- a/src/playground/brio.py
+++ b/src/playground/brio.py
@@ -1,0 +1,38 @@
+def parse_priority(value: str) -> dict[str, object]:
+    """Parse a Brio priority value into a normalized priority summary."""
+    normalized = value.strip().lower()
+    level = _parse_level(normalized)
+
+    if level is None:
+        level = 3
+
+    label = "normal" if level == 3 else f"p{level}"
+    return {
+        "level": level,
+        "label": label,
+        "urgent": level in {0, 1},
+    }
+
+
+def _parse_level(value: str) -> int | None:
+    if value == "normal":
+        return 3
+
+    if value.startswith("priority:"):
+        return _parse_known_level(value.removeprefix("priority:").strip())
+
+    if value.startswith("p"):
+        return _parse_known_level(value.removeprefix("p").strip())
+
+    return _parse_known_level(value)
+
+
+def _parse_known_level(value: str) -> int | None:
+    if not value.isdecimal():
+        return None
+
+    level = int(value)
+    if level in {0, 1, 2, 3}:
+        return level
+
+    return None

--- a/tests/test_brio.py
+++ b/tests/test_brio.py
@@ -1,0 +1,29 @@
+from playground.brio import parse_priority
+
+
+def test_parse_priority_numeric_forms() -> None:
+    assert parse_priority("P0") == {"level": 0, "label": "p0", "urgent": True}
+    assert parse_priority(" p1 ") == {"level": 1, "label": "p1", "urgent": True}
+    assert parse_priority("2") == {"level": 2, "label": "p2", "urgent": False}
+
+
+def test_parse_priority_prefix_form() -> None:
+    assert parse_priority("priority:2") == {"level": 2, "label": "p2", "urgent": False}
+
+
+def test_parse_priority_normal_fallback() -> None:
+    assert parse_priority(" NORMAL ") == {
+        "level": 3,
+        "label": "normal",
+        "urgent": False,
+    }
+
+
+def test_parse_priority_unknown_fallback() -> None:
+    assert parse_priority("soon") == {"level": 3, "label": "normal", "urgent": False}
+
+
+def test_parse_priority_urgent_calculation() -> None:
+    assert parse_priority("priority:0")["urgent"] is True
+    assert parse_priority("priority:1")["urgent"] is True
+    assert parse_priority("priority:2")["urgent"] is False


### PR DESCRIPTION
## Summary
- add isolated Brio parse_priority helper
- normalize priority forms, normal fallback, unknown fallback, and urgent flag calculation
- add focused pytest coverage for numeric forms, priority prefix, normal, unknown, and urgent behavior

## Validation
- pytest tests/test_brio.py
- pytest
- uv pip install --python /tmp/playground-github89-uvvenv/bin/python -e '.[test]'
- /tmp/playground-github89-uvvenv/bin/python -m pytest

Note: direct python3 -m pip install -e '.[test]' was blocked by the system Python PEP 668 externally-managed-environment guard, so install validation used an external uv-created venv.