### PR TITLE
Add flux retry schedule helper

### DIFF
--- a/src/playground/flux.py
+++ b/src/playground/flux.py
@@ -1,0 +1,10 @@
+def retry_delays(attempts: int, base: int = 2, cap: int = 60) -> list[int]:
+    """Return capped exponential retry delays."""
+    if attempts < 0:
+        raise ValueError("attempts must be non-negative")
+    if base <= 0:
+        raise ValueError("base must be positive")
+    if cap <= 0:
+        raise ValueError("cap must be positive")
+
+    return [min(base * 2**index, cap) for index in range(attempts)]

--- a/tests/test_flux.py
+++ b/tests/test_flux.py
@@ -1,0 +1,34 @@
+import pytest
+
+from playground.flux import retry_delays
+
+
+def test_retry_delays_returns_empty_list_for_zero_attempts() -> None:
+    assert retry_delays(0) == []
+
+
+def test_retry_delays_uses_basic_exponential_schedule() -> None:
+    assert retry_delays(5) == [2, 4, 8, 16, 32]
+
+
+def test_retry_delays_caps_each_delay() -> None:
+    assert retry_delays(6, cap=10) == [2, 4, 8, 10, 10, 10]
+
+
+def test_retry_delays_accepts_custom_base() -> None:
+    assert retry_delays(4, base=3) == [3, 6, 12, 24]
+
+
+@pytest.mark.parametrize(
+    ("attempts", "base", "cap"),
+    [
+        (-1, 2, 60),
+        (1, 0, 60),
+        (1, 2, 0),
+    ],
+)
+def test_retry_delays_rejects_invalid_arguments(
+    attempts: int, base: int, cap: int
+) -> None:
+    with pytest.raises(ValueError):
+        retry_delays(attempts, base=base, cap=cap)


### PR DESCRIPTION
## Summary
- add retry_delays helper for capped exponential retry schedules
- validate attempts, base, and cap inputs
- add focused pytest coverage for zero attempts, exponential behavior, caps, custom base, and invalid arguments

## Verification
- pytest tests/test_flux.py
- pytest
- uv pip install --python /tmp/playground-github93-uvvenv/bin/python -e '.[test]'
- /tmp/playground-github93-uvvenv/bin/python -m pytest

Closes #93