### PR TITLE
Add grove slug builder

### DIFF
--- a/src/playground/grove.py
+++ b/src/playground/grove.py
@@ -1,0 +1,20 @@
+import re
+import unicodedata
+
+
+_NON_ALNUM = re.compile(r"[^a-z0-9]+")
+
+
+def make_slug(value: str, max_length: int = 48) -> str:
+    """Build a lowercase ASCII slug from a text value."""
+    if max_length <= 0:
+        raise ValueError("max_length must be positive")
+
+    normalized = unicodedata.normalize("NFKD", value)
+    ascii_value = normalized.encode("ascii", "ignore").decode("ascii").lower()
+    slug = _NON_ALNUM.sub("-", ascii_value).strip("-")
+
+    if slug == "":
+        return "item"
+
+    return slug[:max_length].rstrip("-") or "item"

--- a/tests/test_grove.py
+++ b/tests/test_grove.py
@@ -20,6 +20,7 @@ def test_make_slug_trims_to_max_length_without_trailing_hyphen() -> None:
 
 
 def test_make_slug_returns_item_for_empty_result() -> None:
+    assert make_slug("") == "item"
     assert make_slug(" !!! ") == "item"
 
 

--- a/tests/test_grove.py
+++ b/tests/test_grove.py
@@ -1,0 +1,28 @@
+import pytest
+
+from playground.grove import make_slug
+
+
+def test_make_slug_replaces_punctuation_with_hyphens() -> None:
+    assert make_slug("Hello, Grove!") == "hello-grove"
+
+
+def test_make_slug_collapses_repeated_separators() -> None:
+    assert make_slug("alpha --- beta___gamma") == "alpha-beta-gamma"
+
+
+def test_make_slug_transliterates_unicode_accents() -> None:
+    assert make_slug("Crème Brûlée déjà vu") == "creme-brulee-deja-vu"
+
+
+def test_make_slug_trims_to_max_length_without_trailing_hyphen() -> None:
+    assert make_slug("alpha beta gamma", max_length=11) == "alpha-beta"
+
+
+def test_make_slug_returns_item_for_empty_result() -> None:
+    assert make_slug(" !!! ") == "item"
+
+
+def test_make_slug_requires_positive_max_length() -> None:
+    with pytest.raises(ValueError, match="max_length must be positive"):
+        make_slug("grove", max_length=0)


### PR DESCRIPTION
## Summary
- add isolated grove make_slug helper
- normalize text to lowercase ASCII, collapse non-alphanumeric runs, trim length safely, and fall back to item
- add focused pytest coverage for punctuation, repeated separators, unicode accents, max length trimming, literal empty input, punctuation-only empty output, and invalid max_length

## Review update
- added explicit make_slug("") == "item" coverage requested in review

## Verification
- pytest tests/test_grove.py
- pytest
- python3 -m pip install --target /tmp/playground-github94-pip -e '.[test]'
- PYTHONPATH=/tmp/playground-github94-pip python3 -m pytest