### PR TITLE
Add helio color parser

### DIFF
--- a/src/playground/helio.py
+++ b/src/playground/helio.py
@@ -1,0 +1,23 @@
+from string import hexdigits
+
+
+def parse_hex_color(value: str) -> tuple[int, int, int]:
+    """Parse a short or long hex color into RGB components."""
+    color = value.strip()
+    if color.startswith("#"):
+        color = color[1:]
+
+    if len(color) not in (3, 6):
+        raise ValueError("hex color must contain 3 or 6 hex digits")
+
+    if any(character not in hexdigits for character in color):
+        raise ValueError("hex color contains non-hex characters")
+
+    if len(color) == 3:
+        color = "".join(character * 2 for character in color)
+
+    return (
+        int(color[0:2], 16),
+        int(color[2:4], 16),
+        int(color[4:6], 16),
+    )

--- a/tests/test_helio.py
+++ b/tests/test_helio.py
@@ -1,0 +1,29 @@
+import pytest
+
+from playground.helio import parse_hex_color
+
+
+def test_parse_hex_color_handles_short_form_with_hash() -> None:
+    assert parse_hex_color("#0af") == (0, 170, 255)
+
+
+def test_parse_hex_color_handles_short_form_without_hash() -> None:
+    assert parse_hex_color("3c7") == (51, 204, 119)
+
+
+def test_parse_hex_color_handles_long_form_with_hash() -> None:
+    assert parse_hex_color("#1234ab") == (18, 52, 171)
+
+
+def test_parse_hex_color_handles_long_form_without_hash() -> None:
+    assert parse_hex_color("00AAff") == (0, 170, 255)
+
+
+def test_parse_hex_color_ignores_surrounding_whitespace() -> None:
+    assert parse_hex_color(" \n#c0ffee\t") == (192, 255, 238)
+
+
+@pytest.mark.parametrize("value", ["", "#12", "1234", "#12345", "1234567", "#ggg"])
+def test_parse_hex_color_rejects_invalid_values(value: str) -> None:
+    with pytest.raises(ValueError):
+        parse_hex_color(value)


### PR DESCRIPTION
## Summary
- Add isolated helio hex color parser for short and long RGB forms
- Support optional leading # and surrounding whitespace
- Add pytest coverage for accepted forms and invalid values

## Validation
- pytest tests/test_helio.py
- pytest
- uv pip install --python /tmp/playground-github95-uvvenv/bin/python -e '.[test]'
- /tmp/playground-github95-uvvenv/bin/python -m pytest

Notes:
- Direct python3 -m pip install -e '.[test]' was blocked by the system Python PEP 668 externally-managed-environment guard.
- python3 -m venv was unavailable because ensurepip is not installed, so install validation used an external uv-created venv.
- uv warned that the package has no extra named test; pyproject.toml was not edited per issue scope.