### PR TITLE
Add iris interval merger

### DIFF
--- a/src/playground/iris.py
+++ b/src/playground/iris.py
@@ -1,0 +1,23 @@
+"""Interval merging helper for closed integer ranges."""
+
+
+def merge_intervals(intervals: list[tuple[int, int]]) -> list[tuple[int, int]]:
+    """Return sorted, merged closed intervals without mutating the input list."""
+    sorted_intervals = sorted(intervals, key=lambda interval: interval[0])
+    merged: list[tuple[int, int]] = []
+
+    for start, end in sorted_intervals:
+        if start > end:
+            raise ValueError("interval start must be less than or equal to end")
+
+        if not merged:
+            merged.append((start, end))
+            continue
+
+        previous_start, previous_end = merged[-1]
+        if start <= previous_end + 1:
+            merged[-1] = (previous_start, max(previous_end, end))
+        else:
+            merged.append((start, end))
+
+    return merged

--- a/tests/test_iris.py
+++ b/tests/test_iris.py
@@ -1,0 +1,36 @@
+import pytest
+
+from playground.iris import merge_intervals
+
+
+def test_merge_intervals_returns_empty_list_for_empty_input() -> None:
+    assert merge_intervals([]) == []
+
+
+def test_merge_intervals_preserves_sorted_separated_intervals() -> None:
+    assert merge_intervals([(1, 2), (5, 7), (10, 10)]) == [(1, 2), (5, 7), (10, 10)]
+
+
+def test_merge_intervals_sorts_unsorted_input_before_merging() -> None:
+    assert merge_intervals([(8, 9), (1, 3), (5, 6)]) == [(1, 3), (5, 6), (8, 9)]
+
+
+def test_merge_intervals_merges_overlapping_closed_intervals() -> None:
+    assert merge_intervals([(1, 4), (2, 6), (6, 8)]) == [(1, 8)]
+
+
+def test_merge_intervals_merges_directly_adjacent_intervals() -> None:
+    assert merge_intervals([(1, 2), (3, 5), (7, 7), (6, 6)]) == [(1, 7)]
+
+
+def test_merge_intervals_rejects_invalid_intervals() -> None:
+    with pytest.raises(ValueError):
+        merge_intervals([(1, 3), (5, 4)])
+
+
+def test_merge_intervals_does_not_mutate_input_list() -> None:
+    intervals = [(5, 7), (1, 2), (3, 4)]
+    original = list(intervals)
+
+    assert merge_intervals(intervals) == [(1, 7)]
+    assert intervals == original


### PR DESCRIPTION
## Summary
- Add isolated iris interval merger for closed integer intervals
- Validate interval ordering, sort before merging, and merge overlaps plus direct adjacency
- Cover empty, sorted, unsorted, overlap, adjacency, separated, invalid, and immutability cases

## Verification
- pytest tests/test_iris.py
- pytest
- python3 -m pip install --target /tmp/playground-github96-pip -e '.[test]'
- PYTHONPATH=/tmp/playground-github96-pip python3 -m pytest

Closes #96