### PR TITLE
Add jasper checksum helper

### DIFF
--- a/src/playground/jasper.py
+++ b/src/playground/jasper.py
@@ -1,0 +1,12 @@
+def weighted_checksum(value: str) -> int:
+    """Return a weighted ordinal checksum modulo 97."""
+    total = sum(
+        position * ord(character)
+        for position, character in enumerate(value, 1)
+    )
+    return total % 97
+
+
+def append_checksum(value: str) -> str:
+    """Append the two-digit weighted checksum to a value."""
+    return f"{value}-{weighted_checksum(value):02d}"

--- a/tests/test_jasper.py
+++ b/tests/test_jasper.py
@@ -1,0 +1,18 @@
+from playground.jasper import append_checksum, weighted_checksum
+
+
+def test_weighted_checksum_handles_empty_value() -> None:
+    assert weighted_checksum("") == 0
+
+
+def test_weighted_checksum_handles_single_character() -> None:
+    assert weighted_checksum("A") == 65
+
+
+def test_weighted_checksum_uses_position_weights() -> None:
+    assert weighted_checksum("Jasper") == 19
+
+
+def test_append_checksum_formats_two_digit_suffix() -> None:
+    assert append_checksum("ab") == "ab-02"
+    assert append_checksum("") == "-00"


### PR DESCRIPTION
## Summary
- add isolated Jasper weighted checksum helper
- add append formatting helper with two-digit checksum suffix
- cover empty, single-character, multi-character, and append formatting cases

## Validation
- pytest tests/test_jasper.py
- pytest
- uv pip install --python /tmp/playground-github97-uvvenv/bin/python -e '.[test]'\n- /tmp/playground-github97-uvvenv/bin/python -m pytest tests/test_jasper.py\n\nCloses #97