### PR TITLE
Add kiln config flattener

### DIFF
--- a/src/playground/kiln.py
+++ b/src/playground/kiln.py
@@ -1,0 +1,21 @@
+def flatten_config(data: dict[str, object], sep: str = ".") -> dict[str, object]:
+    """Flatten nested dictionaries into separator-joined leaf keys."""
+    if not sep:
+        raise ValueError("sep must be non-empty")
+
+    flattened: dict[str, object] = {}
+
+    def visit(prefix: str, value: object) -> None:
+        if isinstance(value, dict):
+            for key, nested_value in value.items():
+                nested_key = str(key)
+                next_key = f"{prefix}{sep}{nested_key}" if prefix else nested_key
+                visit(next_key, nested_value)
+            return
+
+        flattened[prefix] = value
+
+    for key, value in data.items():
+        visit(key, value)
+
+    return flattened

--- a/tests/test_kiln.py
+++ b/tests/test_kiln.py
@@ -1,0 +1,82 @@
+import copy
+
+import pytest
+
+from playground.kiln import flatten_config
+
+
+def test_flatten_config_flattens_nested_data() -> None:
+    data: dict[str, object] = {
+        "service": {
+            "host": "localhost",
+            "database": {
+                "port": 5432,
+                "ssl": True,
+            },
+        },
+        "debug": False,
+    }
+
+    assert flatten_config(data) == {
+        "service.host": "localhost",
+        "service.database.port": 5432,
+        "service.database.ssl": True,
+        "debug": False,
+    }
+
+
+def test_flatten_config_preserves_lists_without_traversing() -> None:
+    data: dict[str, object] = {
+        "service": {
+            "ports": [80, 443],
+            "routes": [{"path": "/health"}],
+        },
+    }
+
+    result = flatten_config(data)
+
+    assert result == {
+        "service.ports": [80, 443],
+        "service.routes": [{"path": "/health"}],
+    }
+    service = data["service"]
+    assert isinstance(service, dict)
+    assert result["service.ports"] is service["ports"]
+
+
+def test_flatten_config_omits_empty_dictionaries() -> None:
+    data: dict[str, object] = {
+        "service": {
+            "empty": {},
+            "nested": {"empty": {}},
+            "host": "localhost",
+        },
+        "root_empty": {},
+    }
+
+    assert flatten_config(data) == {"service.host": "localhost"}
+
+
+def test_flatten_config_accepts_custom_separator() -> None:
+    data: dict[str, object] = {"service": {"database": {"port": 5432}}}
+
+    assert flatten_config(data, sep="__") == {"service__database__port": 5432}
+
+
+def test_flatten_config_rejects_empty_separator() -> None:
+    with pytest.raises(ValueError):
+        flatten_config({"service": {"host": "localhost"}}, sep="")
+
+
+def test_flatten_config_does_not_mutate_input() -> None:
+    data: dict[str, object] = {
+        "service": {
+            "database": {"port": 5432},
+            "features": ["metrics", "alerts"],
+        },
+    }
+    original = copy.deepcopy(data)
+
+    flatten_config(data)
+
+    assert data == original


### PR DESCRIPTION
## Summary

- Add isolated kiln config flattener for nested dictionaries.

- Preserve lists and scalar values without traversal, omit empty dictionaries, and validate non-empty separators.
## Verification
- pytest tests/test_kiln.py
- pytest

- PYTHONPATH=/tmp/playground-github98-pip python3 -m pytest
