### PR TITLE
Add lyric phrase counter

### DIFF
--- a/src/playground/lyric.py
+++ b/src/playground/lyric.py
@@ -1,0 +1,8 @@
+def count_phrases(text: str, phrases: list[str]) -> dict[str, int]:
+    """Count non-overlapping phrase occurrences case-insensitively."""
+    normalized_text = text.casefold()
+
+    return {
+        phrase: 0 if phrase == "" else normalized_text.count(phrase.casefold())
+        for phrase in phrases
+    }

--- a/tests/test_lyric.py
+++ b/tests/test_lyric.py
@@ -1,0 +1,29 @@
+from playground.lyric import count_phrases
+
+
+def test_count_phrases_is_case_insensitive() -> None:
+    assert count_phrases("La LA la", ["la", "LA"]) == {"la": 3, "LA": 3}
+
+
+def test_count_phrases_counts_repeated_non_overlapping_occurrences() -> None:
+    assert count_phrases("aaaa", ["aa"]) == {"aa": 2}
+
+
+def test_count_phrases_counts_multi_word_phrases() -> None:
+    text = "We will rock you, we WILL rock you"
+
+    assert count_phrases(text, ["we will rock you", "rock you"]) == {
+        "we will rock you": 2,
+        "rock you": 2,
+    }
+
+
+def test_count_phrases_returns_zero_for_empty_phrase() -> None:
+    assert count_phrases("anything", [""]) == {"": 0}
+
+
+def test_count_phrases_returns_zero_when_no_matches() -> None:
+    assert count_phrases("quiet verse", ["chorus", "bridge"]) == {
+        "chorus": 0,
+        "bridge": 0,
+    }


### PR DESCRIPTION
## Summary
- add isolated lyric phrase counter for case-insensitive literal phrase matching
- count non-overlapping occurrences independently for each phrase
- cover case-insensitive, repeated, multi-word, empty phrase, and no-match cases

## Validation
- pytest tests/test_lyric.py
- pytest
- uv pip install --python /tmp/playground-github99-uvvenv/bin/python -e '.[test]'
- /tmp/playground-github99-uvvenv/bin/python -m pytest

Notes: direct python3 -m pip install -e '.[test]' is blocked by the system Python PEP 668 externally-managed-environment guard, so install validation used an external uv-created venv. The project currently has no extra named test.