### PR TITLE
Add meadow rolling average helper

### DIFF
--- a/src/playground/meadow.py
+++ b/src/playground/meadow.py
@@ -1,0 +1,16 @@
+def rolling_average(values: list[float], window: int) -> list[float]:
+    if window <= 0:
+        raise ValueError("window must be positive")
+
+    averages: list[float] = []
+    total = 0.0
+
+    for index, value in enumerate(values):
+        total += value
+        if index >= window:
+            total -= values[index - window]
+
+        count = min(index + 1, window)
+        averages.append(total / count)
+
+    return averages

--- a/tests/test_meadow.py
+++ b/tests/test_meadow.py
@@ -1,0 +1,36 @@
+import pytest
+
+from playground.meadow import rolling_average
+
+
+def test_rolling_average_window_one_returns_float_values() -> None:
+    result = rolling_average([2.0, 4.0, 6.0], 1)
+
+    assert result == [2.0, 4.0, 6.0]
+    assert all(isinstance(value, float) for value in result)
+
+
+def test_rolling_average_uses_larger_window() -> None:
+    assert rolling_average([2.0, 4.0, 6.0, 10.0], 3) == [2.0, 3.0, 4.0, 20.0 / 3.0]
+
+
+def test_rolling_average_handles_window_larger_than_data() -> None:
+    assert rolling_average([1.0, 3.0, 8.0], 5) == [1.0, 2.0, 4.0]
+
+
+def test_rolling_average_rejects_invalid_window() -> None:
+    with pytest.raises(ValueError):
+        rolling_average([1.0], 0)
+
+
+def test_rolling_average_handles_empty_list() -> None:
+    assert rolling_average([], 3) == []
+
+
+def test_rolling_average_does_not_mutate_input() -> None:
+    values = [3.0, 6.0, 9.0]
+    original = values.copy()
+
+    rolling_average(values, 2)
+
+    assert values == original


### PR DESCRIPTION
## Summary
- add `playground.meadow.rolling_average`
- validate positive windows and compute averages over available trailing values
- cover window size behavior, invalid windows, empty input, float results, and input immutability

## Verification
- `pytest tests/test_meadow.py`
- `pytest`
- `python3 -m pip install --target /tmp/playground-github100-pip -e '.[test]'`
- `PYTHONPATH=/tmp/playground-github100-pip python3 -m pytest`

Note: direct `python3 -m pip install -e '.[test]'` is blocked by the system Python PEP 668 externally-managed-environment guard, so editable install verification used an isolated `/tmp` target.

Closes #100
