### PR TITLE
Add nimble command splitter

### DIFF
--- a/src/playground/nimble.py
+++ b/src/playground/nimble.py
@@ -1,0 +1,32 @@
+def split_commands(text: str) -> list[str]:
+    """Split semicolon-delimited commands outside quoted text."""
+    commands: list[str] = []
+    current: list[str] = []
+    quote: str | None = None
+
+    for character in text:
+        if character in {"'", '"'}:
+            if quote is None:
+                quote = character
+            elif quote == character:
+                quote = None
+            current.append(character)
+            continue
+
+        if character == ";" and quote is None:
+            command = "".join(current).strip()
+            if command:
+                commands.append(command)
+            current = []
+            continue
+
+        current.append(character)
+
+    if quote is not None:
+        raise ValueError(f"unmatched {quote} quote")
+
+    command = "".join(current).strip()
+    if command:
+        commands.append(command)
+
+    return commands

--- a/tests/test_nimble.py
+++ b/tests/test_nimble.py
@@ -1,0 +1,49 @@
+import pytest
+
+from playground.nimble import split_commands
+
+
+def test_split_commands_splits_simple_semicolon_delimited_commands() -> None:
+    assert split_commands("build;test;deploy") == ["build", "test", "deploy"]
+
+
+def test_split_commands_keeps_semicolons_inside_single_quotes() -> None:
+    assert split_commands("say 'hello; there'; run") == [
+        "say 'hello; there'",
+        "run",
+    ]
+
+
+def test_split_commands_keeps_semicolons_inside_double_quotes() -> None:
+    assert split_commands('say "hello; there"; run') == [
+        'say "hello; there"',
+        "run",
+    ]
+
+
+def test_split_commands_handles_mixed_quote_types() -> None:
+    text = 'alpha "keep; this"; beta \'and "this; too"\'; gamma'
+
+    assert split_commands(text) == [
+        'alpha "keep; this"',
+        'beta \'and "this; too"\'',
+        "gamma",
+    ]
+
+
+def test_split_commands_drops_empty_entries() -> None:
+    assert split_commands("alpha;; ; beta;") == ["alpha", "beta"]
+
+
+def test_split_commands_strips_whitespace_around_commands() -> None:
+    assert split_commands("  alpha  ;\n beta\t ; gamma  ") == [
+        "alpha",
+        "beta",
+        "gamma",
+    ]
+
+
+@pytest.mark.parametrize("text", ["alpha 'unterminated", 'alpha "unterminated'])
+def test_split_commands_raises_for_unmatched_quotes(text: str) -> None:
+    with pytest.raises(ValueError):
+        split_commands(text)


### PR DESCRIPTION
## Summary
- add playground.nimble.split_commands for semicolon splitting outside single and double quotes
- preserve quoted command text, trim returned commands, drop empty entries, and reject unmatched quotes
- add focused pytest coverage for issue #101 requirements

## Verification
- pytest tests/test_nimble.py
- pytest
- python3 -m pip install -e '.[test]' (blocked by PEP 668 externally-managed environment)
- python3 -m pip install --target /tmp/playground-github101-pip -e '.[test]'
- PYTHONPATH=/tmp/playground-github101-pip python3 -m pytest

Closes #101