### PR TITLE
Add onyx score normalizer

### DIFF
--- a/src/playground/onyx.py
+++ b/src/playground/onyx.py
@@ -1,0 +1,13 @@
+def normalize_scores(scores: dict[str, float]) -> dict[str, float]:
+    """Scale score values into the 0.0 to 1.0 range."""
+    if not scores:
+        return {}
+
+    minimum = min(scores.values())
+    maximum = max(scores.values())
+
+    if minimum == maximum:
+        return {key: 0.0 for key in scores}
+
+    spread = maximum - minimum
+    return {key: (value - minimum) / spread for key, value in scores.items()}

--- a/tests/test_onyx.py
+++ b/tests/test_onyx.py
@@ -1,0 +1,53 @@
+from playground.onyx import normalize_scores
+
+
+def test_normalize_scores_scales_values() -> None:
+    scores = {"low": 2.0, "middle": 4.0, "high": 6.0}
+
+    assert normalize_scores(scores) == {
+        "low": 0.0,
+        "middle": 0.5,
+        "high": 1.0,
+    }
+
+
+def test_normalize_scores_handles_negative_values() -> None:
+    scores = {"cold": -10.0, "mild": 0.0, "hot": 10.0}
+
+    assert normalize_scores(scores) == {
+        "cold": 0.0,
+        "mild": 0.5,
+        "hot": 1.0,
+    }
+
+
+def test_normalize_scores_returns_zeroes_when_values_are_equal() -> None:
+    scores = {"first": 7.0, "second": 7.0, "third": 7.0}
+
+    assert normalize_scores(scores) == {
+        "first": 0.0,
+        "second": 0.0,
+        "third": 0.0,
+    }
+
+
+def test_normalize_scores_returns_empty_dictionary_for_empty_input() -> None:
+    assert normalize_scores({}) == {}
+
+
+def test_normalize_scores_preserves_keys() -> None:
+    scores = {"onyx": 3.0, "slate": 9.0, "jet": 6.0}
+
+    result = normalize_scores(scores)
+
+    assert result.keys() == scores.keys()
+
+
+def test_normalize_scores_does_not_mutate_input() -> None:
+    scores = {"onyx": 3.0, "slate": 9.0}
+    original = scores.copy()
+
+    result = normalize_scores(scores)
+
+    assert scores == original
+    assert result is not scores


### PR DESCRIPTION
## Summary
- add isolated onyx score normalizer using min-max normalization
- handle empty inputs and equal-valued scores without mutating input
- add focused pytest coverage for scaling, negative values, equal values, empty input, key preservation, and immutability

## Verification
- pytest tests/test_onyx.py
- pytest
- python3 -m pip install --target /tmp/playground-github102-pip -e '.[test]'
- PYTHONPATH=/tmp/playground-github102-pip python3 -m pytest

Note: direct python3 -m pip install -e '.[test]' is blocked by the system Python PEP 668 externally-managed-environment guard, so install validation used an isolated /tmp target. pip also warns that the package has no extra named test.