### PR TITLE
Add spline range compressor

### DIFF
--- a/src/playground/spline.py
+++ b/src/playground/spline.py
@@ -1,0 +1,26 @@
+def compress_ranges(values: list[int]) -> str:
+    """Compress integer values into comma-delimited consecutive ranges."""
+    sorted_values = sorted(set(values))
+    if not sorted_values:
+        return ""
+
+    parts: list[str] = []
+    start = previous = sorted_values[0]
+
+    for value in sorted_values[1:]:
+        if value == previous + 1:
+            previous = value
+            continue
+
+        parts.append(_format_range(start, previous))
+        start = previous = value
+
+    parts.append(_format_range(start, previous))
+    return ",".join(parts)
+
+
+def _format_range(start: int, end: int) -> str:
+    if start == end:
+        return str(start)
+
+    return f"{start}-{end}"

--- a/tests/test_spline.py
+++ b/tests/test_spline.py
@@ -1,0 +1,35 @@
+from playground.spline import compress_ranges
+
+
+def test_compress_ranges_returns_empty_string_for_empty_input() -> None:
+    assert compress_ranges([]) == ""
+
+
+def test_compress_ranges_renders_singletons() -> None:
+    assert compress_ranges([4]) == "4"
+
+
+def test_compress_ranges_renders_consecutive_runs() -> None:
+    assert compress_ranges([1, 2, 3, 4]) == "1-4"
+
+
+def test_compress_ranges_sorts_and_deduplicates_values() -> None:
+    assert compress_ranges([4, 2, 3, 3, 1, 2]) == "1-4"
+
+
+def test_compress_ranges_handles_negative_values() -> None:
+    assert compress_ranges([-3, -2, -1, 1]) == "-3--1,1"
+
+
+def test_compress_ranges_renders_separated_ranges() -> None:
+    assert compress_ranges([1, 2, 4, 6, 7, 8, 10]) == "1-2,4,6-8,10"
+
+
+def test_compress_ranges_does_not_mutate_input() -> None:
+    values = [3, 1, 2, 2]
+    original = values.copy()
+
+    result = compress_ranges(values)
+
+    assert result == "1-3"
+    assert values == original


### PR DESCRIPTION
## Summary
- add playground.spline.compress_ranges
- sort and de-duplicate input values before rendering ranges
- cover empty input, singletons, consecutive runs, duplicates, negatives, separated ranges, and immutability

## Verification
- PIP_BREAK_SYSTEM_PACKAGES=1 python3 -m pip install -e .[test]
- pytest

Closes #121