### PR TITLE
Add timber tree walker

### DIFF
--- a/src/playground/timber.py
+++ b/src/playground/timber.py
@@ -1,0 +1,20 @@
+def walk_tree(tree: dict[str, object]) -> list[str]:
+    """Return dot-separated paths to every leaf in a nested dictionary tree."""
+    paths: list[str] = []
+
+    def visit(path: str, value: object) -> None:
+        if not isinstance(value, dict):
+            paths.append(path)
+            return
+
+        if not value:
+            paths.append(path)
+            return
+
+        for key in sorted(value):
+            visit(f"{path}.{key}", value[key])
+
+    for key in sorted(tree):
+        visit(key, tree[key])
+
+    return paths

--- a/tests/test_timber.py
+++ b/tests/test_timber.py
@@ -1,0 +1,72 @@
+import copy
+
+from playground.timber import walk_tree
+
+
+def test_walk_tree_returns_nested_leaf_paths() -> None:
+    tree: dict[str, object] = {
+        "forest": {
+            "oak": {"height": 12, "rings": 80},
+            "pine": {"needles": True},
+        },
+        "clearing": "sunny",
+    }
+
+    assert walk_tree(tree) == [
+        "clearing",
+        "forest.oak.height",
+        "forest.oak.rings",
+        "forest.pine.needles",
+    ]
+
+
+def test_walk_tree_uses_depth_first_alphabetical_key_order() -> None:
+    tree: dict[str, object] = {
+        "b": {"d": 1, "c": 2},
+        "a": {"z": 3, "m": {"n": 4}},
+    }
+
+    assert walk_tree(tree) == ["a.m.n", "a.z", "b.c", "b.d"]
+
+
+def test_walk_tree_returns_empty_list_for_empty_root() -> None:
+    assert walk_tree({}) == []
+
+
+def test_walk_tree_includes_empty_child_dictionaries_as_leaves() -> None:
+    tree: dict[str, object] = {
+        "branch": {
+            "empty": {},
+            "nested": {"empty": {}},
+        },
+        "root_empty": {},
+    }
+
+    assert walk_tree(tree) == [
+        "branch.empty",
+        "branch.nested.empty",
+        "root_empty",
+    ]
+
+
+def test_walk_tree_includes_scalar_leaves() -> None:
+    tree: dict[str, object] = {
+        "count": 3,
+        "enabled": False,
+        "name": "timber",
+        "none": None,
+    }
+
+    assert walk_tree(tree) == ["count", "enabled", "name", "none"]
+
+
+def test_walk_tree_does_not_mutate_input() -> None:
+    tree: dict[str, object] = {
+        "z": {"b": [1, 2], "a": {"leaf": True}},
+        "a": {},
+    }
+    original = copy.deepcopy(tree)
+
+    walk_tree(tree)
+
+    assert tree == original


### PR DESCRIPTION
## Summary
- Add playground.timber.walk_tree for depth-first alphabetical leaf path traversal.
- Treat empty child dictionaries as leaf paths while empty roots return no paths.
- Add pytest coverage for ordering, scalar leaves, empty dictionaries, and immutability.

## Verification
- PIP_BREAK_SYSTEM_PACKAGES=1 python3 -m pip install -e .[test]
- pytest

Closes #122