### PR TITLE
Add quill front matter parser

### DIFF
--- a/src/playground/quill.py
+++ b/src/playground/quill.py
@@ -1,0 +1,24 @@
+def parse_front_matter(text: str) -> tuple[dict[str, str], str]:
+    """Parse YAML-like front matter from the start of text."""
+    lines = text.splitlines(keepends=True)
+    if not lines or lines[0].rstrip("\r\n") != "---":
+        return {}, text
+
+    metadata: dict[str, str] = {}
+
+    for index, line in enumerate(lines[1:], start=1):
+        content = line.rstrip("\r\n")
+        if content == "---":
+            return metadata, "".join(lines[index + 1 :])
+        if not content.strip():
+            continue
+        if ":" not in content:
+            raise ValueError(f"malformed front matter line: {content}")
+
+        key, value = content.split(":", 1)
+        key = key.strip()
+        if not key:
+            raise ValueError(f"malformed front matter line: {content}")
+        metadata[key] = value.strip()
+
+    raise ValueError("missing closing front matter delimiter")

--- a/tests/test_quill.py
+++ b/tests/test_quill.py
@@ -1,0 +1,54 @@
+import pytest
+
+from playground.quill import parse_front_matter
+
+
+def test_parse_front_matter_parses_metadata_and_body() -> None:
+    text = "---\ntitle: Hello\nslug: hello-world\n---\nBody text\n"
+
+    metadata, body = parse_front_matter(text)
+
+    assert metadata == {"title": "Hello", "slug": "hello-world"}
+    assert body == "Body text\n"
+
+
+def test_parse_front_matter_returns_original_text_without_opening_delimiter() -> None:
+    text = "title: Hello\n---\nBody text\n"
+
+    metadata, body = parse_front_matter(text)
+
+    assert metadata == {}
+    assert body == text
+
+
+def test_parse_front_matter_ignores_blank_lines() -> None:
+    text = "---\n\n title :  Hello  \n   \ncategory: Notes\n---\nBody\n"
+
+    metadata, body = parse_front_matter(text)
+
+    assert metadata == {"title": "Hello", "category": "Notes"}
+    assert body == "Body\n"
+
+
+def test_parse_front_matter_raises_for_malformed_nonblank_line() -> None:
+    text = "---\ntitle Hello\n---\nBody\n"
+
+    with pytest.raises(ValueError, match="malformed front matter line"):
+        parse_front_matter(text)
+
+
+def test_parse_front_matter_raises_for_missing_closing_delimiter() -> None:
+    text = "---\ntitle: Hello\nsummary: Body\n"
+
+    with pytest.raises(ValueError, match="missing closing front matter delimiter"):
+        parse_front_matter(text)
+
+
+def test_parse_front_matter_preserves_body_exactly_after_closing_delimiter() -> None:
+    body = "\n# Heading\n\nBody: with colon\n---\n"
+    text = f"---\ntitle: Hello\n---\n{body}"
+
+    metadata, parsed_body = parse_front_matter(text)
+
+    assert metadata == {"title": "Hello"}
+    assert parsed_body == body


### PR DESCRIPTION
## Summary
- add isolated quill front matter parser
- cover parsing, absent delimiters, blank lines, malformed metadata, missing close delimiter, and body preservation

## Verification
- PIP_BREAK_SYSTEM_PACKAGES=1 python3 -m pip install -e .[test]
- pytest

Closes #119