### PR TITLE
Add radix unit converter

### DIFF
--- a/src/playground/radix.py
+++ b/src/playground/radix.py
@@ -1,0 +1,33 @@
+UNITS = {
+    "B": 1,
+    "KB": 1024,
+    "MB": 1024**2,
+    "GB": 1024**3,
+}
+
+
+def convert_bytes(value: int, unit: str = "auto") -> dict[str, object]:
+    """Convert a byte count to the requested base-1024 unit."""
+    if value < 0:
+        raise ValueError("value must be non-negative")
+
+    normalized_unit = unit.upper()
+    if normalized_unit == "AUTO":
+        normalized_unit = _auto_unit(value)
+
+    if normalized_unit not in UNITS:
+        raise ValueError(f"unsupported unit: {unit}")
+
+    converted = value / UNITS[normalized_unit]
+    return {
+        "value": converted,
+        "unit": normalized_unit,
+        "text": f"{converted:.2f} {normalized_unit}",
+    }
+
+
+def _auto_unit(value: int) -> str:
+    for unit in ("GB", "MB", "KB"):
+        if value / UNITS[unit] >= 1:
+            return unit
+    return "B"

--- a/tests/test_radix.py
+++ b/tests/test_radix.py
@@ -1,0 +1,82 @@
+import pytest
+
+from playground.radix import convert_bytes
+
+
+def test_convert_bytes_to_bytes() -> None:
+    assert convert_bytes(1536, "B") == {
+        "value": 1536.0,
+        "unit": "B",
+        "text": "1536.00 B",
+    }
+
+
+def test_convert_bytes_to_kilobytes() -> None:
+    assert convert_bytes(1536, "KB") == {
+        "value": 1.5,
+        "unit": "KB",
+        "text": "1.50 KB",
+    }
+
+
+def test_convert_bytes_to_megabytes() -> None:
+    assert convert_bytes(3 * 1024**2, "MB") == {
+        "value": 3.0,
+        "unit": "MB",
+        "text": "3.00 MB",
+    }
+
+
+def test_convert_bytes_to_gigabytes() -> None:
+    assert convert_bytes(5 * 1024**3, "GB") == {
+        "value": 5.0,
+        "unit": "GB",
+        "text": "5.00 GB",
+    }
+
+
+def test_convert_bytes_matches_units_case_insensitively() -> None:
+    assert convert_bytes(2048, "kb") == {
+        "value": 2.0,
+        "unit": "KB",
+        "text": "2.00 KB",
+    }
+
+
+@pytest.mark.parametrize(
+    ("value", "expected_unit", "expected_text"),
+    [
+        (0, "B", "0.00 B"),
+        (1023, "B", "1023.00 B"),
+        (1024, "KB", "1.00 KB"),
+        (1024**2 - 1, "KB", "1024.00 KB"),
+        (1024**2, "MB", "1.00 MB"),
+        (1024**3 - 1, "MB", "1024.00 MB"),
+        (1024**3, "GB", "1.00 GB"),
+    ],
+)
+def test_convert_bytes_auto_boundaries(
+    value: int, expected_unit: str, expected_text: str
+) -> None:
+    result = convert_bytes(value)
+
+    assert result["unit"] == expected_unit
+    assert result["text"] == expected_text
+
+
+def test_convert_bytes_matches_auto_case_insensitively() -> None:
+    assert convert_bytes(1024, "Auto") == {
+        "value": 1.0,
+        "unit": "KB",
+        "text": "1.00 KB",
+    }
+
+
+def test_convert_bytes_rejects_invalid_unit() -> None:
+    with pytest.raises(ValueError, match="unsupported unit"):
+        convert_bytes(1024, "TB")
+
+
+def test_convert_bytes_rejects_negative_value() -> None:
+    with pytest.raises(ValueError, match="non-negative"):
+        convert_bytes(-1)


### PR DESCRIPTION
## Summary
- add playground.radix.convert_bytes for B, KB, MB, and GB conversions using base 1024
- support case-insensitive units, auto unit selection, formatted text output, and validation errors
- add pytest coverage for explicit units, auto boundaries, invalid unit, negative values, and zero

## Validation
- PIP_BREAK_SYSTEM_PACKAGES=1 python3 -m pip install -e .[test]
- pytest

Closes #120