### PR TITLE
Add pylon dependency sorter

### DIFF
--- a/src/playground/pylon.py
+++ b/src/playground/pylon.py
@@ -1,0 +1,49 @@
+from heapq import heappop, heappush
+
+
+def sort_dependencies(graph: dict[str, list[str]]) -> list[str]:
+    """Return a deterministic topological order for a dependency graph."""
+    nodes: set[str] = set(graph)
+    dependency_counts: dict[str, int] = {node: 0 for node in graph}
+    dependents: dict[str, set[str]] = {node: set() for node in graph}
+
+    for node, dependencies in graph.items():
+        unique_dependencies = set(dependencies)
+        nodes.update(unique_dependencies)
+        dependency_counts.setdefault(node, 0)
+
+        for dependency in unique_dependencies:
+            dependency_counts.setdefault(dependency, 0)
+            dependents.setdefault(dependency, set()).add(node)
+            dependency_counts[node] += 1
+
+    for node in nodes:
+        dependency_counts.setdefault(node, 0)
+        dependents.setdefault(node, set())
+
+    available: list[str] = []
+    for node in sorted(nodes):
+        if dependency_counts[node] == 0:
+            heappush(available, node)
+
+    ordered: list[str] = []
+    while available:
+        node = heappop(available)
+        ordered.append(node)
+
+        for dependent in dependents[node]:
+            dependency_counts[dependent] -= 1
+            if dependency_counts[dependent] == 0:
+                heappush(available, dependent)
+
+    if len(ordered) != len(nodes):
+        cycle_nodes = sorted(node for node in nodes if dependency_counts[node] > 0)
+        raise ValueError(
+            "cycle detected in dependency graph involving: "
+            + ", ".join(cycle_nodes)
+        )
+
+    return ordered
+
+
+__all__ = ["sort_dependencies"]

--- a/tests/test_pylon.py
+++ b/tests/test_pylon.py
@@ -1,0 +1,74 @@
+import pytest
+
+from playground.pylon import sort_dependencies
+
+
+def test_sort_dependencies_orders_simple_chain() -> None:
+    graph = {
+        "app": ["service"],
+        "service": ["database"],
+        "database": [],
+    }
+
+    assert sort_dependencies(graph) == ["database", "service", "app"]
+
+
+def test_sort_dependencies_orders_branching_graph() -> None:
+    graph = {
+        "app": ["api", "worker"],
+        "api": ["database"],
+        "worker": ["database", "queue"],
+        "database": [],
+        "queue": [],
+    }
+
+    assert sort_dependencies(graph) == [
+        "database",
+        "api",
+        "queue",
+        "worker",
+        "app",
+    ]
+
+
+def test_sort_dependencies_includes_dependency_only_nodes() -> None:
+    assert sort_dependencies({"app": ["runtime"]}) == ["runtime", "app"]
+
+
+def test_sort_dependencies_sorts_available_nodes_alphabetically() -> None:
+    graph = {
+        "zeta": [],
+        "alpha": [],
+        "release": ["zeta", "alpha"],
+    }
+
+    assert sort_dependencies(graph) == ["alpha", "zeta", "release"]
+
+
+def test_sort_dependencies_raises_useful_error_for_cycles() -> None:
+    graph = {
+        "build": ["test"],
+        "test": ["build"],
+        "lint": [],
+    }
+
+    with pytest.raises(ValueError, match="cycle.*build.*test"):
+        sort_dependencies(graph)
+
+
+def test_sort_dependencies_does_not_mutate_input_graph_or_lists() -> None:
+    dependencies = ["beta", "alpha"]
+    graph = {
+        "release": dependencies,
+        "alpha": [],
+        "beta": [],
+    }
+    original = {
+        node: list(node_dependencies)
+        for node, node_dependencies in graph.items()
+    }
+
+    sort_dependencies(graph)
+
+    assert graph == original
+    assert dependencies == ["beta", "alpha"]


### PR DESCRIPTION
## Summary
- Add playground.pylon.sort_dependencies for deterministic topological ordering
- Include dependency-only nodes without mutating input graph data
- Raise useful ValueError messages for cyclic dependency graphs
- Add pytest coverage for chains, branching, dependency-only nodes, deterministic order, cycles, and immutability

## Validation
- PIP_BREAK_SYSTEM_PACKAGES=1 python3 -m pip install -e .[test]
- pytest tests/test_pylon.py
- pytest