### PR TITLE
Add vault policy matcher

### DIFF
--- a/src/playground/vault.py
+++ b/src/playground/vault.py
@@ -1,0 +1,54 @@
+import re
+
+
+def match_policy(path: str, rules: dict[str, str]) -> str | None:
+    """Return the policy for the most specific matching vault path rule."""
+    normalized_path = _normalize_path(path)
+    matches = [
+        pattern for pattern in rules if _pattern_matches(pattern, normalized_path)
+    ]
+    if not matches:
+        return None
+
+    best_pattern = min(matches, key=lambda pattern: (-len(pattern), pattern))
+    return rules[best_pattern]
+
+
+def _normalize_path(path: str) -> str:
+    return re.sub(r"/+", "/", path)
+
+
+def _pattern_matches(pattern: str, path: str) -> bool:
+    pattern_segments = pattern.split("/")
+    path_segments = path.split("/")
+
+    def matches_from(pattern_index: int, path_index: int) -> bool:
+        if pattern_index == len(pattern_segments):
+            return path_index == len(path_segments)
+
+        pattern_segment = pattern_segments[pattern_index]
+        if pattern_segment == "**":
+            if pattern_index == len(pattern_segments) - 1:
+                return True
+            return any(
+                matches_from(pattern_index + 1, next_path_index)
+                for next_path_index in range(path_index, len(path_segments) + 1)
+            )
+
+        if path_index == len(path_segments):
+            return False
+
+        return _segment_matches(
+            pattern_segment,
+            path_segments[path_index],
+        ) and matches_from(pattern_index + 1, path_index + 1)
+
+    return matches_from(0, 0)
+
+
+def _segment_matches(pattern: str, segment: str) -> bool:
+    regex = "".join(
+        "[^/]*" if character == "*" else re.escape(character)
+        for character in pattern
+    )
+    return re.fullmatch(regex, segment) is not None

--- a/tests/test_vault.py
+++ b/tests/test_vault.py
@@ -1,0 +1,63 @@
+from playground.vault import match_policy
+
+
+def test_match_policy_returns_exact_match() -> None:
+    rules = {
+        "secret/app/config": "app-config",
+        "secret/app/token": "app-token",
+    }
+
+    assert match_policy("secret/app/config", rules) == "app-config"
+
+
+def test_match_policy_supports_single_star_within_one_segment() -> None:
+    rules = {
+        "secret/app-*/config": "app-config",
+    }
+
+    assert match_policy("secret/app-prod/config", rules) == "app-config"
+    assert match_policy("secret/app-prod/us/config", rules) is None
+
+
+def test_match_policy_supports_double_star_across_segments() -> None:
+    rules = {
+        "secret/**/config": "nested-config",
+    }
+
+    assert match_policy("secret/team/app/config", rules) == "nested-config"
+    assert match_policy("secret/config", rules) == "nested-config"
+
+
+def test_match_policy_chooses_longest_matching_pattern() -> None:
+    rules = {
+        "secret/**": "broad",
+        "secret/app/*": "app",
+        "secret/app/config": "config",
+    }
+
+    assert match_policy("secret/app/config", rules) == "config"
+
+
+def test_match_policy_uses_alphabetical_tie_breaker() -> None:
+    rules = {
+        "secret/a*": "prefix",
+        "secret/*a": "suffix",
+    }
+
+    assert match_policy("secret/aa", rules) == "suffix"
+
+
+def test_match_policy_returns_none_when_nothing_matches() -> None:
+    rules = {
+        "secret/app/*": "app",
+    }
+
+    assert match_policy("secret/app/prod/config", rules) is None
+
+
+def test_match_policy_normalizes_repeated_slashes_in_input_path() -> None:
+    rules = {
+        "secret/app/config": "app-config",
+    }
+
+    assert match_policy("secret//app///config", rules) == "app-config"


### PR DESCRIPTION
## Summary
- add isolated vault policy matcher for exact, single-star, and double-star rules
- choose the most specific matching pattern by length and alphabetical order
- add focused pytest coverage for matching, specificity, tie-breaking, no match, and repeated slash normalization

## Verification
- PIP_BREAK_SYSTEM_PACKAGES=1 python3 -m pip install -e .[test]
- pytest tests/test_vault.py
- pytest

Closes #124