### PR TITLE
Add xylem CSV row normalizer

### DIFF
--- a/src/playground/xylem.py
+++ b/src/playground/xylem.py
@@ -1,0 +1,29 @@
+import csv
+from io import StringIO
+
+
+def normalize_csv_rows(text: str) -> list[dict[str, str]]:
+    """Parse CSV text into stripped dictionaries keyed by the header row."""
+    reader = csv.reader(StringIO(text, newline=""))
+
+    try:
+        header_row = next(reader)
+    except StopIteration:
+        return []
+
+    headers = [header.strip() for header in header_row]
+    rows: list[dict[str, str]] = []
+
+    for row in reader:
+        cells = [cell.strip() for cell in row]
+        if not any(cells):
+            continue
+
+        rows.append(
+            {
+                header: cells[index] if index < len(cells) else ""
+                for index, header in enumerate(headers)
+            }
+        )
+
+    return rows

--- a/tests/test_xylem.py
+++ b/tests/test_xylem.py
@@ -1,0 +1,46 @@
+from playground.xylem import normalize_csv_rows
+
+
+def test_normalize_csv_rows_parses_normal_csv() -> None:
+    text = "name,age\nAda,36\nGrace,85\n"
+
+    assert normalize_csv_rows(text) == [
+        {"name": "Ada", "age": "36"},
+        {"name": "Grace", "age": "85"},
+    ]
+
+
+def test_normalize_csv_rows_trims_headers_and_cell_values() -> None:
+    text = " name , age \n Ada , 36 \n"
+
+    assert normalize_csv_rows(text) == [{"name": "Ada", "age": "36"}]
+
+
+def test_normalize_csv_rows_ignores_completely_blank_rows() -> None:
+    text = "name,age\n\n   ,   \nAda,36\n"
+
+    assert normalize_csv_rows(text) == [{"name": "Ada", "age": "36"}]
+
+
+def test_normalize_csv_rows_fills_missing_cells_with_empty_strings() -> None:
+    text = "name,age,city\nAda,36\n"
+
+    assert normalize_csv_rows(text) == [{"name": "Ada", "age": "36", "city": ""}]
+
+
+def test_normalize_csv_rows_ignores_extra_cells() -> None:
+    text = "name,age\nAda,36,London\n"
+
+    assert normalize_csv_rows(text) == [{"name": "Ada", "age": "36"}]
+
+
+def test_normalize_csv_rows_preserves_quoted_commas() -> None:
+    text = 'name,note\nAda,"engineer, mathematician"\n'
+
+    assert normalize_csv_rows(text) == [
+        {"name": "Ada", "note": "engineer, mathematician"}
+    ]
+
+
+def test_normalize_csv_rows_returns_empty_list_for_empty_input() -> None:
+    assert normalize_csv_rows("") == []


### PR DESCRIPTION
## Summary
- Add normalize_csv_rows in src/playground/xylem.py using the standard library CSV parser
- Strip headers and values, skip completely blank rows, pad missing cells, and ignore extra cells
- Add pytest coverage for normal CSV, trimming, blank rows, missing cells, extra cells, quoted commas, and empty input

## Verification
- PIP_BREAK_SYSTEM_PACKAGES=1 python3 -m pip install -e .[test]
- pytest tests/test_xylem.py
- pytest
- git diff --check

Closes #126