### PR TITLE
Add yarrow diff summary helper

### DIFF
--- a/src/playground/yarrow.py
+++ b/src/playground/yarrow.py
@@ -1,0 +1,25 @@
+def summarize_diff(lines: list[str]) -> dict[str, int]:
+    """Summarize unified diff lines by change class."""
+    summary = {
+        "added": 0,
+        "removed": 0,
+        "context": 0,
+        "metadata": 0,
+    }
+
+    for line in lines:
+        if line.startswith(("+++", "---", "@@")):
+            summary["metadata"] += 1
+        elif line.startswith("+"):
+            summary["added"] += 1
+        elif line.startswith("-"):
+            summary["removed"] += 1
+        elif line.startswith(" "):
+            summary["context"] += 1
+        else:
+            summary["metadata"] += 1
+
+    return summary
+
+
+__all__ = ["summarize_diff"]

--- a/tests/test_yarrow.py
+++ b/tests/test_yarrow.py
@@ -1,0 +1,94 @@
+from playground.yarrow import summarize_diff
+
+
+def test_summarize_diff_counts_all_line_classes() -> None:
+    lines = [
+        "+added line",
+        "-removed line",
+        " unchanged line",
+        "diff --git a/file b/file",
+    ]
+
+    assert summarize_diff(lines) == {
+        "added": 1,
+        "removed": 1,
+        "context": 1,
+        "metadata": 1,
+    }
+
+
+def test_summarize_diff_treats_file_headers_as_metadata() -> None:
+    lines = [
+        "+++ b/app.py",
+        "--- a/app.py",
+        "+real addition",
+        "-real removal",
+    ]
+
+    assert summarize_diff(lines) == {
+        "added": 1,
+        "removed": 1,
+        "context": 0,
+        "metadata": 2,
+    }
+
+
+def test_summarize_diff_treats_hunk_headers_as_metadata() -> None:
+    lines = [
+        "@@ -1,2 +1,3 @@",
+        " context",
+        "+added",
+    ]
+
+    assert summarize_diff(lines) == {
+        "added": 1,
+        "removed": 0,
+        "context": 1,
+        "metadata": 1,
+    }
+
+
+def test_summarize_diff_counts_mixed_unified_diff() -> None:
+    lines = [
+        "diff --git a/example.txt b/example.txt",
+        "index 1111111..2222222 100644",
+        "--- a/example.txt",
+        "+++ b/example.txt",
+        "@@ -1,4 +1,5 @@",
+        " kept",
+        "-old",
+        "+new",
+        "+extra",
+        "\\ No newline at end of file",
+    ]
+
+    assert summarize_diff(lines) == {
+        "added": 2,
+        "removed": 1,
+        "context": 1,
+        "metadata": 6,
+    }
+
+
+def test_summarize_diff_returns_zero_counts_for_empty_input() -> None:
+    assert summarize_diff([]) == {
+        "added": 0,
+        "removed": 0,
+        "context": 0,
+        "metadata": 0,
+    }
+
+
+def test_summarize_diff_does_not_mutate_input() -> None:
+    lines = [
+        "--- a/file.txt",
+        "+++ b/file.txt",
+        "@@ -1 +1 @@",
+        "-before",
+        "+after",
+    ]
+    original = list(lines)
+
+    summarize_diff(lines)
+
+    assert lines == original


### PR DESCRIPTION
## Summary
- Add `playground.yarrow.summarize_diff` for unified diff line classification.
- Count added, removed, context, and metadata lines while treating `+++`, `---`, and `@@` headers as metadata.
- Cover empty input and input immutability.

## Verification
- `PIP_BREAK_SYSTEM_PACKAGES=1 python3 -m pip install -e .[test]`
- `pytest tests/test_yarrow.py`
- `pytest`
- `git diff --check`

Closes #127
