### PR TITLE
Add zenith score bands

### DIFF
--- a/src/playground/zenith.py
+++ b/src/playground/zenith.py
@@ -1,0 +1,25 @@
+"""Zenith score band helpers."""
+
+BAND_KEYS = ("low", "medium", "high", "elite")
+
+
+def score_band(score: float) -> str:
+    """Return the zenith band for a score between 0 and 100 inclusive."""
+    if not 0 <= score <= 100:
+        raise ValueError("score must be between 0 and 100 inclusive")
+
+    if score < 50:
+        return "low"
+    if score < 80:
+        return "medium"
+    if score < 95:
+        return "high"
+    return "elite"
+
+
+def summarize_bands(scores: list[float]) -> dict[str, int]:
+    """Count zenith score bands for the provided scores."""
+    summary = dict.fromkeys(BAND_KEYS, 0)
+    for score in scores:
+        summary[score_band(score)] += 1
+    return summary

--- a/tests/test_zenith.py
+++ b/tests/test_zenith.py
@@ -1,0 +1,48 @@
+import pytest
+
+from playground.zenith import score_band, summarize_bands
+
+
+@pytest.mark.parametrize(
+    ("score", "expected"),
+    [
+        (0, "low"),
+        (49.999, "low"),
+        (50, "medium"),
+        (79.999, "medium"),
+        (80, "high"),
+        (94.999, "high"),
+        (95, "elite"),
+        (100, "elite"),
+    ],
+)
+def test_score_band_boundaries(score, expected):
+    assert score_band(score) == expected
+
+
+@pytest.mark.parametrize("score", [-0.001, 100.001])
+def test_score_band_rejects_scores_outside_inclusive_range(score):
+    with pytest.raises(ValueError, match="between 0 and 100"):
+        score_band(score)
+
+
+def test_summarize_bands_counts_scores_by_band():
+    assert summarize_bands([10, 49.999, 50, 80, 94.999, 95, 100]) == {
+        "low": 2,
+        "medium": 1,
+        "high": 2,
+        "elite": 2,
+    }
+
+
+def test_summarize_bands_empty_summary_includes_all_bands():
+    assert summarize_bands([]) == {
+        "low": 0,
+        "medium": 0,
+        "high": 0,
+        "elite": 0,
+    }
+
+
+def test_summarize_bands_returns_all_band_keys_when_counts_are_zero():
+    assert set(summarize_bands([100])) == {"low", "medium", "high", "elite"}


### PR DESCRIPTION
## Summary
- add isolated zenith score band classification helper
- add band summary counts that always include low, medium, high, and elite
- cover boundaries, invalid values, empty summaries, and all band keys

## Validation
- PIP_BREAK_SYSTEM_PACKAGES=1 python3 -m pip install -e .[test]
- pytest tests/test_zenith.py
- pytest
- git diff --check

Closes #128