### PR TITLE
Add beacon2 event grouper

### DIFF
--- a/src/playground/beacon2.py
+++ b/src/playground/beacon2.py
@@ -1,0 +1,11 @@
+def group_events(
+    events: list[dict[str, object]], key: str
+) -> dict[str, list[dict[str, object]]]:
+    groups: dict[str, list[dict[str, object]]] = {}
+
+    for event in events:
+        value = event.get(key)
+        group_key = "unknown" if value is None else str(value)
+        groups.setdefault(group_key, []).append(dict(event))
+
+    return {group_key: groups[group_key] for group_key in sorted(groups)}

--- a/tests/test_beacon2.py
+++ b/tests/test_beacon2.py
@@ -1,0 +1,83 @@
+from playground.beacon2 import group_events
+
+
+def test_group_events_groups_by_requested_key() -> None:
+    events: list[dict[str, object]] = [
+        {"kind": "click", "id": 1},
+        {"kind": "view", "id": 2},
+        {"kind": "click", "id": 3},
+    ]
+
+    assert group_events(events, "kind") == {
+        "click": [
+            {"kind": "click", "id": 1},
+            {"kind": "click", "id": 3},
+        ],
+        "view": [{"kind": "view", "id": 2}],
+    }
+
+
+def test_group_events_uses_unknown_for_missing_and_none_keys() -> None:
+    events: list[dict[str, object]] = [
+        {"kind": None, "id": 1},
+        {"id": 2},
+        {"kind": "view", "id": 3},
+    ]
+
+    assert group_events(events, "kind") == {
+        "unknown": [{"kind": None, "id": 1}, {"id": 2}],
+        "view": [{"kind": "view", "id": 3}],
+    }
+
+
+def test_group_events_preserves_original_order_within_groups() -> None:
+    events: list[dict[str, object]] = [
+        {"kind": "view", "id": 1},
+        {"kind": "click", "id": 2},
+        {"kind": "view", "id": 3},
+        {"kind": "click", "id": 4},
+    ]
+
+    grouped = group_events(events, "kind")
+
+    assert [event["id"] for event in grouped["click"]] == [2, 4]
+    assert [event["id"] for event in grouped["view"]] == [1, 3]
+
+
+def test_group_events_returns_group_keys_sorted_alphabetically() -> None:
+    events: list[dict[str, object]] = [
+        {"kind": "zebra"},
+        {"kind": "alpha"},
+        {"kind": "middle"},
+    ]
+
+    assert list(group_events(events, "kind")) == ["alpha", "middle", "zebra"]
+
+
+def test_group_events_converts_non_string_values_to_group_keys() -> None:
+    events: list[dict[str, object]] = [
+        {"status": 200, "path": "/ok"},
+        {"status": False, "path": "/disabled"},
+        {"status": 200, "path": "/health"},
+    ]
+
+    assert group_events(events, "status") == {
+        "200": [
+            {"status": 200, "path": "/ok"},
+            {"status": 200, "path": "/health"},
+        ],
+        "False": [{"status": False, "path": "/disabled"}],
+    }
+
+
+def test_group_events_does_not_mutate_input_events() -> None:
+    events: list[dict[str, object]] = [
+        {"kind": "click", "id": 1},
+        {"kind": None, "id": 2},
+    ]
+    original = [dict(event) for event in events]
+
+    grouped = group_events(events, "kind")
+    grouped["click"][0]["id"] = 99
+
+    assert events == original


### PR DESCRIPTION
## Summary
- add isolated beacon2 group_events helper
- group missing or None values under unknown and stringify other group values
- preserve per-group event order, sorted group keys, and input event immutability

## Validation
- python3 -m pip install -e .[test] (blocked by PEP 668 externally-managed environment)
- PIP_BREAK_SYSTEM_PACKAGES=1 python3 -m pip install -e .[test]
- pytest tests/test_beacon2.py
- pytest
- git diff --check