### PR TITLE
Add cairn markdown outline

### DIFF
--- a/src/playground/cairn.py
+++ b/src/playground/cairn.py
@@ -1,0 +1,32 @@
+import re
+
+
+_HEADING_PATTERN = re.compile(r"^(#+) (.*)$")
+_FENCE_MARKER = "```"
+
+
+def markdown_outline(text: str) -> list[dict[str, object]]:
+    """Return ATX headings found outside triple-backtick fenced code blocks."""
+    outline: list[dict[str, object]] = []
+    in_fence = False
+
+    for line in text.splitlines():
+        if line.strip().startswith(_FENCE_MARKER):
+            in_fence = not in_fence
+            continue
+
+        if in_fence:
+            continue
+
+        match = _HEADING_PATTERN.match(line)
+        if match is None:
+            continue
+
+        level = len(match.group(1))
+        if level > 6:
+            continue
+
+        title = match.group(2).strip().rstrip("#").strip()
+        outline.append({"level": level, "title": title})
+
+    return outline

--- a/tests/test_cairn.py
+++ b/tests/test_cairn.py
@@ -1,0 +1,69 @@
+from playground.cairn import markdown_outline
+
+
+def test_markdown_outline_parses_heading_levels() -> None:
+    text = "\n".join(
+        [
+            "# Page",
+            "## Section",
+            "### Subsection",
+            "#### Detail",
+            "##### Note",
+            "###### Fine print",
+        ]
+    )
+
+    assert markdown_outline(text) == [
+        {"level": 1, "title": "Page"},
+        {"level": 2, "title": "Section"},
+        {"level": 3, "title": "Subsection"},
+        {"level": 4, "title": "Detail"},
+        {"level": 5, "title": "Note"},
+        {"level": 6, "title": "Fine print"},
+    ]
+
+
+def test_markdown_outline_ignores_invalid_headings() -> None:
+    text = "\n".join(
+        [
+            "#Valid without required space",
+            "####### Too deep",
+            " ## Indented",
+            "# Valid",
+        ]
+    )
+
+    assert markdown_outline(text) == [{"level": 1, "title": "Valid"}]
+
+
+def test_markdown_outline_ignores_headings_inside_fenced_code() -> None:
+    text = "\n".join(
+        [
+            "# Outside",
+            "```python",
+            "## Inside",
+            "```",
+            "### Outside again",
+        ]
+    )
+
+    assert markdown_outline(text) == [
+        {"level": 1, "title": "Outside"},
+        {"level": 3, "title": "Outside again"},
+    ]
+
+
+def test_markdown_outline_strips_trailing_hash_markers() -> None:
+    assert markdown_outline("## Section ###") == [
+        {"level": 2, "title": "Section"}
+    ]
+
+
+def test_markdown_outline_strips_surrounding_title_whitespace() -> None:
+    assert markdown_outline("###   Spaced title   ###   ") == [
+        {"level": 3, "title": "Spaced title"}
+    ]
+
+
+def test_markdown_outline_returns_empty_list_for_empty_text() -> None:
+    assert markdown_outline("") == []


### PR DESCRIPTION
## Summary
- add isolated cairn markdown outline helper
- parse ATX headings outside triple-backtick fenced code blocks
- cover levels, invalid headings, fences, trailing hashes, whitespace, and empty input

## Verification
- PIP_BREAK_SYSTEM_PACKAGES=1 python3 -m pip install -e .[test]
- pytest tests/test_cairn.py
- pytest
- git diff --check origin/main...HEAD

Closes #130