### PR TITLE
Add ember2 histogram builder

### DIFF
--- a/src/playground/ember2.py
+++ b/src/playground/ember2.py
@@ -1,0 +1,35 @@
+from decimal import Decimal, ROUND_FLOOR
+
+
+def histogram(values: list[float], bucket_size: float) -> dict[str, int]:
+    """Build a histogram with buckets sorted by numeric start."""
+    bucket = Decimal(str(bucket_size))
+    if bucket <= 0:
+        raise ValueError("bucket_size must be positive")
+
+    counts: dict[Decimal, int] = {}
+    for value in values:
+        decimal_value = Decimal(str(value))
+        start = (decimal_value / bucket).to_integral_value(
+            rounding=ROUND_FLOOR
+        ) * bucket
+        counts[start] = counts.get(start, 0) + 1
+
+    return {
+        _label(start, start + bucket): counts[start]
+        for start in sorted(counts)
+    }
+
+
+def _label(start: Decimal, end: Decimal) -> str:
+    return f"{_format_bound(start)}-{_format_bound(end)}"
+
+
+def _format_bound(value: Decimal) -> str:
+    if value == value.to_integral_value():
+        return str(value.quantize(Decimal("1")))
+
+    return format(value.normalize(), "f")
+
+
+__all__ = ["histogram"]

--- a/tests/test_ember2.py
+++ b/tests/test_ember2.py
@@ -1,0 +1,46 @@
+import pytest
+
+from playground.ember2 import histogram
+
+
+def test_histogram_groups_positive_values_by_bucket() -> None:
+    assert histogram([0.2, 0.7, 1.0, 1.9, 2.1], 1.0) == {
+        "0-1": 2,
+        "1-2": 2,
+        "2-3": 1,
+    }
+
+
+def test_histogram_supports_negative_values() -> None:
+    assert histogram([-2.1, -2.0, -1.2, -0.1, 0.0], 1.0) == {
+        "-3--2": 1,
+        "-2--1": 2,
+        "-1-0": 1,
+        "0-1": 1,
+    }
+
+
+def test_histogram_supports_fractional_bucket_size() -> None:
+    assert histogram([0.1, 0.4, 0.5, 0.9, 1.0], 0.5) == {
+        "0-0.5": 2,
+        "0.5-1": 2,
+        "1-1.5": 1,
+    }
+
+
+def test_histogram_returns_empty_dict_for_empty_input() -> None:
+    assert histogram([], 1.0) == {}
+
+
+@pytest.mark.parametrize("bucket_size", [0.0, -1.0])
+def test_histogram_rejects_invalid_bucket_size(bucket_size: float) -> None:
+    with pytest.raises(ValueError, match="bucket_size must be positive"):
+        histogram([1.0], bucket_size)
+
+
+def test_histogram_formats_integral_bounds_without_trailing_decimal() -> None:
+    assert histogram([2.0, 2.5, 3.0], 0.5) == {
+        "2-2.5": 1,
+        "2.5-3": 1,
+        "3-3.5": 1,
+    }


### PR DESCRIPTION
## Summary
- add isolated ember2 histogram helper with positive bucket validation
- generate sorted bucket labels with integral bounds formatted without trailing .0
- cover positive, negative, fractional, empty, invalid, and formatting cases

## Validation
- PIP_BREAK_SYSTEM_PACKAGES=1 python3 -m pip install -e .[test]
- pytest tests/test_ember2.py
- pytest
- git diff --check