### PR TITLE
Add delta2 batch chunker

### DIFF
--- a/src/playground/delta2.py
+++ b/src/playground/delta2.py
@@ -1,0 +1,47 @@
+def chunk_by_weight(
+    items: list[dict[str, object]], max_weight: int
+) -> list[list[dict[str, object]]]:
+    """Split items into ordered chunks constrained by item weight."""
+    _validate_positive_integer("max_weight", max_weight)
+
+    chunks: list[list[dict[str, object]]] = []
+    current_chunk: list[dict[str, object]] = []
+    current_weight = 0
+
+    for item in items:
+        weight = _item_weight(item)
+
+        if weight > max_weight:
+            if current_chunk:
+                chunks.append(current_chunk)
+                current_chunk = []
+                current_weight = 0
+            chunks.append([item])
+            continue
+
+        if current_chunk and current_weight + weight > max_weight:
+            chunks.append(current_chunk)
+            current_chunk = []
+            current_weight = 0
+
+        current_chunk.append(item)
+        current_weight += weight
+
+    if current_chunk:
+        chunks.append(current_chunk)
+
+    return chunks
+
+
+def _item_weight(item: dict[str, object]) -> int:
+    weight = item.get("weight", 1)
+    _validate_positive_integer("weight", weight)
+    return weight
+
+
+def _validate_positive_integer(name: str, value: object) -> None:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ValueError(f"{name} must be a positive integer")
+
+
+__all__ = ["chunk_by_weight"]

--- a/tests/test_delta2.py
+++ b/tests/test_delta2.py
@@ -1,0 +1,85 @@
+import copy
+
+import pytest
+
+from playground.delta2 import chunk_by_weight
+
+
+def test_chunk_by_weight_groups_items_without_exceeding_max_weight() -> None:
+    items = [
+        {"id": "a", "weight": 2},
+        {"id": "b", "weight": 3},
+        {"id": "c", "weight": 1},
+        {"id": "d", "weight": 4},
+    ]
+
+    assert chunk_by_weight(items, 5) == [
+        [{"id": "a", "weight": 2}, {"id": "b", "weight": 3}],
+        [{"id": "c", "weight": 1}, {"id": "d", "weight": 4}],
+    ]
+
+
+def test_chunk_by_weight_defaults_missing_weight_to_one() -> None:
+    items = [
+        {"id": "a"},
+        {"id": "b", "weight": 2},
+        {"id": "c"},
+    ]
+
+    assert chunk_by_weight(items, 3) == [
+        [{"id": "a"}, {"id": "b", "weight": 2}],
+        [{"id": "c"}],
+    ]
+
+
+def test_chunk_by_weight_keeps_exact_boundaries_in_same_chunk() -> None:
+    items = [
+        {"id": "a", "weight": 2},
+        {"id": "b", "weight": 2},
+        {"id": "c", "weight": 4},
+    ]
+
+    assert chunk_by_weight(items, 4) == [
+        [{"id": "a", "weight": 2}, {"id": "b", "weight": 2}],
+        [{"id": "c", "weight": 4}],
+    ]
+
+
+def test_chunk_by_weight_places_overweight_item_in_own_chunk() -> None:
+    items = [
+        {"id": "a", "weight": 2},
+        {"id": "b", "weight": 7},
+        {"id": "c", "weight": 1},
+        {"id": "d", "weight": 3},
+    ]
+
+    assert chunk_by_weight(items, 4) == [
+        [{"id": "a", "weight": 2}],
+        [{"id": "b", "weight": 7}],
+        [{"id": "c", "weight": 1}, {"id": "d", "weight": 3}],
+    ]
+
+
+@pytest.mark.parametrize("max_weight", [0, -1, 1.5, True])
+def test_chunk_by_weight_rejects_invalid_max_weight(max_weight: object) -> None:
+    with pytest.raises(ValueError, match="max_weight"):
+        chunk_by_weight([{"id": "a"}], max_weight)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("weight", [0, -1, 1.5, "2", False])
+def test_chunk_by_weight_rejects_invalid_item_weight(weight: object) -> None:
+    with pytest.raises(ValueError, match="weight"):
+        chunk_by_weight([{"id": "a", "weight": weight}], 5)
+
+
+def test_chunk_by_weight_does_not_mutate_input() -> None:
+    items = [
+        {"id": "a", "weight": 2, "tags": ["ready"]},
+        {"id": "b"},
+        {"id": "c", "weight": 3},
+    ]
+    original = copy.deepcopy(items)
+
+    chunk_by_weight(items, 3)
+
+    assert items == original


### PR DESCRIPTION
## Summary
- add isolated delta2 chunk_by_weight helper
- validate positive integer max/item weights with default missing weight of 1
- cover batching boundaries, overweight items, validation, and immutability

## Verification
- PIP_BREAK_SYSTEM_PACKAGES=1 python3 -m pip install -e .[test]
- pytest tests/test_delta2.py
- pytest
- git diff --check