### PR TITLE
Add juniper template renderer

### DIFF
--- a/src/playground/juniper.py
+++ b/src/playground/juniper.py
@@ -1,0 +1,28 @@
+import re
+
+
+_PLACEHOLDER_RE = re.compile(r"{{\s*(.*?)\s*}}")
+
+
+def _lookup_value(path: str, values: dict[str, object]) -> object:
+    current: object = values
+
+    for part in path.split("."):
+        if not isinstance(current, dict) or part not in current:
+            raise KeyError(path)
+        current = current[part]
+
+    return current
+
+
+def render_template(template: str, values: dict[str, object]) -> str:
+    """Render double-brace placeholders from a dictionary of values."""
+
+    def replace(match: re.Match[str]) -> str:
+        path = match.group(1).strip()
+        try:
+            return str(_lookup_value(path, values))
+        except KeyError:
+            return match.group(0)
+
+    return _PLACEHOLDER_RE.sub(replace, template)

--- a/tests/test_juniper.py
+++ b/tests/test_juniper.py
@@ -1,0 +1,46 @@
+from copy import deepcopy
+
+from playground.juniper import render_template
+
+
+def test_render_template_replaces_simple_placeholder() -> None:
+    assert render_template("Hello, {{ name }}!", {"name": "Ada"}) == "Hello, Ada!"
+
+
+def test_render_template_supports_dotted_lookup() -> None:
+    values = {"user": {"name": "Grace"}}
+
+    assert render_template("Hello, {{ user.name }}!", values) == "Hello, Grace!"
+
+
+def test_render_template_leaves_unknown_placeholders_unchanged() -> None:
+    result = render_template("Hello, {{ missing }} and {{ user.email }}.", {"user": {}})
+
+    assert result == "Hello, {{ missing }} and {{ user.email }}."
+
+
+def test_render_template_replaces_repeated_placeholders() -> None:
+    template = "{{ name }} scored for {{ name }}."
+
+    assert render_template(template, {"name": "Juniper"}) == "Juniper scored for Juniper."
+
+
+def test_render_template_strips_whitespace_inside_braces() -> None:
+    template = "{{name}} {{   name   }}"
+
+    assert render_template(template, {"name": "Maple"}) == "Maple Maple"
+
+
+def test_render_template_stringifies_non_string_values() -> None:
+    template = "{{ count }} {{ enabled }}"
+
+    assert render_template(template, {"count": 3, "enabled": True}) == "3 True"
+
+
+def test_render_template_does_not_mutate_values() -> None:
+    values = {"user": {"name": "Ada"}, "count": 2}
+    original = deepcopy(values)
+
+    render_template("{{ user.name }} {{ count }}", values)
+
+    assert values == original


### PR DESCRIPTION
## Summary
- add an isolated Juniper renderer for double-brace placeholders
- support dotted dictionary lookups and preserve unknown placeholders unchanged
- cover replacement, repeated placeholders, whitespace trimming, non-string values, and immutability

## Verification
- python3 -m pytest tests/test_juniper.py
- python3 -m pytest
- git diff --check