### PR TITLE
Add indigo calendar slot finder

### DIFF
--- a/src/playground/indigo.py
+++ b/src/playground/indigo.py
@@ -1,0 +1,38 @@
+def free_slots(
+    busy: list[tuple[int, int]],
+    start: int,
+    end: int,
+    min_duration: int,
+) -> list[tuple[int, int]]:
+    """Return free half-open intervals inside a search window."""
+    if start > end:
+        raise ValueError("start must be less than or equal to end")
+    if min_duration <= 0:
+        raise ValueError("min_duration must be positive")
+
+    clipped_busy = sorted(
+        (max(busy_start, start), min(busy_end, end))
+        for busy_start, busy_end in busy
+        if max(busy_start, start) < min(busy_end, end)
+    )
+
+    merged_busy: list[tuple[int, int]] = []
+    for busy_start, busy_end in clipped_busy:
+        if not merged_busy or busy_start > merged_busy[-1][1]:
+            merged_busy.append((busy_start, busy_end))
+            continue
+
+        merged_start, merged_end = merged_busy[-1]
+        merged_busy[-1] = (merged_start, max(merged_end, busy_end))
+
+    slots: list[tuple[int, int]] = []
+    cursor = start
+    for busy_start, busy_end in merged_busy:
+        if busy_start - cursor >= min_duration:
+            slots.append((cursor, busy_start))
+        cursor = max(cursor, busy_end)
+
+    if end - cursor >= min_duration:
+        slots.append((cursor, end))
+
+    return slots

--- a/tests/test_indigo.py
+++ b/tests/test_indigo.py
@@ -1,0 +1,59 @@
+import pytest
+
+from playground.indigo import free_slots
+
+
+def test_free_slots_returns_gaps_between_busy_intervals() -> None:
+    assert free_slots([(10, 20), (30, 40)], 0, 50, 5) == [
+        (0, 10),
+        (20, 30),
+        (40, 50),
+    ]
+
+
+def test_free_slots_merges_unsorted_overlapping_busy_intervals() -> None:
+    assert free_slots([(25, 30), (10, 20), (18, 26)], 0, 40, 1) == [
+        (0, 10),
+        (30, 40),
+    ]
+
+
+def test_free_slots_clips_busy_intervals_to_search_window() -> None:
+    assert free_slots([(0, 12), (18, 30)], 10, 20, 1) == [(12, 18)]
+
+
+def test_free_slots_returns_empty_when_busy_covers_window() -> None:
+    assert free_slots([(0, 20)], 5, 15, 1) == []
+
+
+def test_free_slots_filters_gaps_shorter_than_min_duration() -> None:
+    assert free_slots([(5, 7), (10, 20), (24, 25)], 0, 30, 5) == [
+        (0, 5),
+        (25, 30),
+    ]
+
+
+@pytest.mark.parametrize(
+    ("start", "end", "min_duration"),
+    [
+        (10, 5, 1),
+        (0, 10, 0),
+        (0, 10, -1),
+    ],
+)
+def test_free_slots_validates_search_window_and_min_duration(
+    start: int,
+    end: int,
+    min_duration: int,
+) -> None:
+    with pytest.raises(ValueError):
+        free_slots([], start, end, min_duration)
+
+
+def test_free_slots_does_not_mutate_busy_intervals() -> None:
+    busy = [(20, 25), (5, 10), (8, 12)]
+    original = list(busy)
+
+    free_slots(busy, 0, 30, 1)
+
+    assert busy == original


### PR DESCRIPTION
## Summary
- add playground.indigo.free_slots for half-open calendar windows
- validate search bounds and minimum duration
- clip, sort, and merge busy intervals before returning qualifying free slots

## Verification
- pytest tests/test_indigo.py
- pytest

Note: python3 -m pip install -e '.[test]' was attempted but the host Python is externally managed by PEP 668; a temporary venv fallback was also unavailable because python3-venv/ensurepip is not installed.