### PR TITLE
Add maven path matcher

### DIFF
--- a/src/playground/maven.py
+++ b/src/playground/maven.py
@@ -1,0 +1,23 @@
+from fnmatch import fnmatchcase
+
+
+def match_paths(
+    paths: list[str],
+    include: list[str],
+    exclude: list[str] | None = None,
+) -> list[str]:
+    """Return paths matched by include patterns and not removed by exclude patterns."""
+    if not include:
+        return []
+
+    exclude_patterns = exclude or []
+    matched: list[str] = []
+
+    for path in paths:
+        if not any(fnmatchcase(path, pattern) for pattern in include):
+            continue
+        if any(fnmatchcase(path, pattern) for pattern in exclude_patterns):
+            continue
+        matched.append(path)
+
+    return matched

--- a/tests/test_maven.py
+++ b/tests/test_maven.py
@@ -1,0 +1,79 @@
+from playground.maven import match_paths
+
+
+def test_match_paths_includes_matching_paths() -> None:
+    paths = [
+        "src/main/java/App.java",
+        "src/main/resources/config.yml",
+        "README.md",
+    ]
+
+    assert match_paths(paths, ["src/main/java/*.java"]) == [
+        "src/main/java/App.java",
+    ]
+
+
+def test_match_paths_excludes_after_inclusion() -> None:
+    paths = [
+        "src/main/java/App.java",
+        "src/test/java/AppTest.java",
+        "src/main/java/Service.java",
+    ]
+
+    assert match_paths(paths, ["src/**/*.java"], ["src/test/**"]) == [
+        "src/main/java/App.java",
+        "src/main/java/Service.java",
+    ]
+
+
+def test_match_paths_accepts_multiple_include_patterns() -> None:
+    paths = [
+        "pom.xml",
+        "src/main/java/App.java",
+        "src/main/resources/application.properties",
+        "docs/usage.md",
+    ]
+
+    assert match_paths(paths, ["pom.xml", "src/main/resources/*"]) == [
+        "pom.xml",
+        "src/main/resources/application.properties",
+    ]
+
+
+def test_match_paths_returns_empty_list_for_empty_include() -> None:
+    assert match_paths(["pom.xml"], []) == []
+
+
+def test_match_paths_preserves_input_order() -> None:
+    paths = [
+        "src/main/java/Third.java",
+        "src/main/java/First.java",
+        "src/main/java/Second.java",
+    ]
+
+    assert match_paths(paths, ["src/main/java/*.java"]) == paths
+
+
+def test_match_paths_returns_empty_list_when_no_paths_match() -> None:
+    assert match_paths(["README.md", "docs/usage.md"], ["src/**/*.java"]) == []
+
+
+def test_match_paths_does_not_mutate_inputs() -> None:
+    paths = [
+        "pom.xml",
+        "src/main/java/App.java",
+        "src/test/java/AppTest.java",
+    ]
+    include = ["pom.xml", "src/**/*.java"]
+    exclude = ["src/test/**"]
+    original_paths = list(paths)
+    original_include = list(include)
+    original_exclude = list(exclude)
+
+    assert match_paths(paths, include, exclude) == [
+        "pom.xml",
+        "src/main/java/App.java",
+    ]
+    assert paths == original_paths
+    assert include == original_include
+    assert exclude == original_exclude


### PR DESCRIPTION
## Summary
- add isolated fnmatch-based Maven path matcher
- cover include, exclude, multiple patterns, empty include, order preservation, no matches, and immutability

## Validation
- python3 -m pip install -e .[test] --break-system-packages
- python3 -m pytest tests/test_maven.py
- python3 -m pytest