### PR TITLE
Add opal retry budget planner

### DIFF
--- a/src/playground/opal.py
+++ b/src/playground/opal.py
@@ -1,0 +1,26 @@
+def plan_retries(deadline_seconds: int, delays: list[int]) -> dict[str, object]:
+    """Return the retry attempts that fit within a delay budget."""
+    if type(deadline_seconds) is not int or deadline_seconds < 0:
+        raise ValueError("deadline_seconds must be a non-negative integer")
+
+    for delay in delays:
+        if type(delay) is not int or delay < 0:
+            raise ValueError("delays must contain non-negative integers")
+
+    schedule: list[int] = []
+    cumulative_delay = 0
+
+    for delay in delays:
+        next_delay = cumulative_delay + delay
+        if next_delay > deadline_seconds:
+            break
+
+        cumulative_delay = next_delay
+        schedule.append(cumulative_delay)
+
+    return {
+        "attempts": len(schedule),
+        "used_seconds": cumulative_delay,
+        "remaining_seconds": deadline_seconds - cumulative_delay,
+        "schedule": schedule,
+    }

--- a/tests/test_opal.py
+++ b/tests/test_opal.py
@@ -1,0 +1,76 @@
+import pytest
+
+from playground.opal import plan_retries
+
+
+def test_plan_retries_returns_attempts_within_budget() -> None:
+    assert plan_retries(10, [1, 2, 3, 5]) == {
+        "attempts": 3,
+        "used_seconds": 6,
+        "remaining_seconds": 4,
+        "schedule": [1, 3, 6],
+    }
+
+
+def test_plan_retries_includes_exact_deadline() -> None:
+    assert plan_retries(6, [1, 2, 3]) == {
+        "attempts": 3,
+        "used_seconds": 6,
+        "remaining_seconds": 0,
+        "schedule": [1, 3, 6],
+    }
+
+
+def test_plan_retries_stops_before_over_budget_delay() -> None:
+    assert plan_retries(5, [2, 4, 0]) == {
+        "attempts": 1,
+        "used_seconds": 2,
+        "remaining_seconds": 3,
+        "schedule": [2],
+    }
+
+
+def test_plan_retries_handles_zero_deadline() -> None:
+    assert plan_retries(0, [0, 0, 1]) == {
+        "attempts": 2,
+        "used_seconds": 0,
+        "remaining_seconds": 0,
+        "schedule": [0, 0],
+    }
+
+
+def test_plan_retries_handles_empty_delays() -> None:
+    assert plan_retries(8, []) == {
+        "attempts": 0,
+        "used_seconds": 0,
+        "remaining_seconds": 8,
+        "schedule": [],
+    }
+
+
+@pytest.mark.parametrize(
+    ("deadline_seconds", "delays"),
+    [
+        (-1, [1]),
+        (5, [-1]),
+        (5, [1, 1.5]),
+        (5, [True]),
+        (False, [1]),
+        (0, [1, -1]),
+    ],
+)
+def test_plan_retries_validates_budget_inputs(
+    deadline_seconds: int,
+    delays: list[int],
+) -> None:
+    with pytest.raises(ValueError):
+        plan_retries(deadline_seconds, delays)
+
+
+def test_plan_retries_does_not_mutate_delays() -> None:
+    delays = [2, 3, 4]
+    original = list(delays)
+
+    plan_retries(5, delays)
+
+    assert delays == original


### PR DESCRIPTION
## Summary
- add isolated opal retry budget planner
- validate non-negative integer deadlines and delays before planning
- cover normal, exact, over-budget, zero deadline, empty, validation, and immutability cases

## Verification
- python3 -m pytest tests/test_opal.py
- PIP_BREAK_SYSTEM_PACKAGES=1 python3 -m pip install -e .[test]
- python3 -m pytest
- git diff --check

Closes #162