### PR TITLE
Add river pagination cursor helper

### DIFF
--- a/src/playground/river.py
+++ b/src/playground/river.py
@@ -1,0 +1,14 @@
+def build_cursor(page: int, per_page: int, total: int) -> dict[str, int | bool]:
+    """Return pagination cursor metadata for a result set."""
+    clamped_per_page = max(per_page, 1)
+    total_pages = max(1, (total + clamped_per_page - 1) // clamped_per_page)
+    clamped_page = min(max(page, 1), total_pages)
+
+    return {
+        "page": clamped_page,
+        "per_page": clamped_per_page,
+        "total": total,
+        "total_pages": total_pages,
+        "has_previous": clamped_page > 1,
+        "has_next": clamped_page < total_pages,
+    }

--- a/tests/test_river.py
+++ b/tests/test_river.py
@@ -1,0 +1,34 @@
+from playground.river import build_cursor
+
+
+def test_build_cursor_reports_first_page() -> None:
+    assert build_cursor(1, 10, 95) == {
+        "page": 1,
+        "per_page": 10,
+        "total": 95,
+        "total_pages": 10,
+        "has_previous": False,
+        "has_next": True,
+    }
+
+
+def test_build_cursor_reports_middle_page() -> None:
+    assert build_cursor(3, 20, 95) == {
+        "page": 3,
+        "per_page": 20,
+        "total": 95,
+        "total_pages": 5,
+        "has_previous": True,
+        "has_next": True,
+    }
+
+
+def test_build_cursor_clamps_over_large_page() -> None:
+    assert build_cursor(99, 0, 3) == {
+        "page": 3,
+        "per_page": 1,
+        "total": 3,
+        "total_pages": 3,
+        "has_previous": True,
+        "has_next": False,
+    }


### PR DESCRIPTION
## Summary
- Add isolated `playground.river.build_cursor` pagination metadata helper
- Clamp page and per_page values, compute ceiling total pages, and expose previous/next flags
- Add focused tests for first, middle, and over-large page behavior

## Validation
- `python3 -m pytest tests/test_river.py`
- `python3 -m pip install -e .[test] --break-system-packages`
- `python3 -m pytest`
- `git diff --check`

Closes #173