### PR TITLE
Add topaz CSV row sanitizer

### DIFF
--- a/src/playground/topaz.py
+++ b/src/playground/topaz.py
@@ -1,0 +1,29 @@
+def sanitize_row(
+    row: dict[str, object],
+    required: list[str] | None = None,
+) -> dict[str, str]:
+    """Return a normalized string-only CSV row."""
+    sanitized: dict[str, str] = {}
+
+    for key, value in row.items():
+        stripped_key = key.strip()
+        if not stripped_key:
+            continue
+
+        if value is None:
+            sanitized[stripped_key] = ""
+        elif isinstance(value, str):
+            sanitized[stripped_key] = value.strip()
+        else:
+            sanitized[stripped_key] = str(value)
+
+    if required is not None:
+        for key in required:
+            stripped_key = key.strip()
+            if stripped_key:
+                sanitized.setdefault(stripped_key, "")
+
+    return sanitized
+
+
+__all__ = ["sanitize_row"]

--- a/tests/test_topaz.py
+++ b/tests/test_topaz.py
@@ -1,0 +1,50 @@
+from playground.topaz import sanitize_row
+
+
+def test_sanitize_row_strips_keys_and_string_values() -> None:
+    row = {
+        " name ": " Ada ",
+        "\temail\n": " ada@example.com ",
+    }
+
+    assert sanitize_row(row) == {
+        "name": "Ada",
+        "email": "ada@example.com",
+    }
+
+
+def test_sanitize_row_drops_blank_keys() -> None:
+    row = {
+        " ": "ignored",
+        "\t\n": "also ignored",
+        "name": "Ada",
+    }
+
+    assert sanitize_row(row) == {"name": "Ada"}
+
+
+def test_sanitize_row_converts_none_and_non_string_values() -> None:
+    row = {
+        "empty": None,
+        "count": 3,
+        "enabled": True,
+    }
+
+    assert sanitize_row(row) == {
+        "empty": "",
+        "count": "3",
+        "enabled": "True",
+    }
+
+
+def test_sanitize_row_adds_required_defaults() -> None:
+    row = {
+        " name ": " Ada ",
+        "email": "ada@example.com",
+    }
+
+    assert sanitize_row(row, required=["name", " company ", "email"]) == {
+        "name": "Ada",
+        "email": "ada@example.com",
+        "company": "",
+    }


### PR DESCRIPTION
## Summary
- add playground.topaz.sanitize_row for CSV row normalization
- strip row keys and string values, drop blank keys, convert None and non-string values to strings
- add required-key defaults with empty strings

## Validation
- PIP_BREAK_SYSTEM_PACKAGES=1 python3 -m pip install -e .[test]
- python3 -m pytest tests/test_topaz.py
- python3 -m pytest
- git diff --cached --check