### PR TITLE
Add zircon release note grouper

### DIFF
--- a/src/playground/zircon.py
+++ b/src/playground/zircon.py
@@ -1,0 +1,13 @@
+def group_notes(items: list[dict[str, str]]) -> dict[str, list[str]]:
+    """Group release note text by normalized type."""
+    groups: dict[str, list[str]] = {}
+
+    for item in items:
+        text = item.get("text", "").strip()
+        if not text:
+            continue
+
+        note_type = item.get("type", "").strip() or "other"
+        groups.setdefault(note_type, []).append(text)
+
+    return {note_type: groups[note_type] for note_type in sorted(groups)}

--- a/tests/test_zircon.py
+++ b/tests/test_zircon.py
@@ -1,0 +1,51 @@
+from playground.zircon import group_notes
+
+
+def test_group_notes_groups_text_by_sorted_type() -> None:
+    items = [
+        {"type": "fix", "text": "repair login"},
+        {"type": "feature", "text": "add dashboard"},
+        {"type": "fix", "text": "handle timeout"},
+    ]
+
+    assert group_notes(items) == {
+        "feature": ["add dashboard"],
+        "fix": ["repair login", "handle timeout"],
+    }
+
+
+def test_group_notes_uses_other_for_missing_or_blank_type() -> None:
+    items = [
+        {"text": "document fallback"},
+        {"type": "", "text": "empty type"},
+        {"type": "  ", "text": "blank type"},
+    ]
+
+    assert group_notes(items) == {
+        "other": ["document fallback", "empty type", "blank type"],
+    }
+
+
+def test_group_notes_strips_and_skips_blank_text() -> None:
+    items = [
+        {"type": "fix", "text": "  trim whitespace  "},
+        {"type": "fix", "text": ""},
+        {"type": "fix", "text": "   "},
+        {"type": "feature"},
+    ]
+
+    assert group_notes(items) == {"fix": ["trim whitespace"]}
+
+
+def test_group_notes_preserves_order_within_each_type() -> None:
+    items = [
+        {"type": "feature", "text": "first feature"},
+        {"type": "fix", "text": "first fix"},
+        {"type": "feature", "text": "second feature"},
+        {"type": "fix", "text": "second fix"},
+    ]
+
+    assert group_notes(items) == {
+        "feature": ["first feature", "second feature"],
+        "fix": ["first fix", "second fix"],
+    }


### PR DESCRIPTION
Closes #177\n\nSummary:\n- Add isolated playground.zircon group_notes helper for release note grouping.\n- Normalize missing or blank types to other, strip and skip blank text, preserve item order within each type, and sort returned type keys.\n- Add focused pytest coverage for grouping, fallback, blank text skipping, and order preservation.\n\nValidation:\n- python3 -m pytest tests/test_zircon.py\n- python3 -m pip install -e .[test] --break-system-packages\n- pytest\n- git diff --check