### PR TITLE
Add umber dependency cycle reporter

### DIFF
--- a/src/playground/umber.py
+++ b/src/playground/umber.py
@@ -1,0 +1,35 @@
+def find_cycle(graph: dict[str, list[str]]) -> list[str]:
+    """Return one deterministic dependency cycle from graph, if present."""
+    nodes = set(graph)
+    for dependencies in graph.values():
+        nodes.update(dependencies)
+
+    visited: set[str] = set()
+    visiting: set[str] = set()
+    stack: list[str] = []
+
+    def visit(node: str) -> list[str]:
+        visiting.add(node)
+        stack.append(node)
+
+        for neighbor in sorted(graph.get(node, [])):
+            if neighbor in visiting:
+                cycle_start = stack.index(neighbor)
+                return stack[cycle_start:] + [neighbor]
+            if neighbor not in visited:
+                cycle = visit(neighbor)
+                if cycle:
+                    return cycle
+
+        stack.pop()
+        visiting.remove(node)
+        visited.add(node)
+        return []
+
+    for node in sorted(nodes):
+        if node not in visited:
+            cycle = visit(node)
+            if cycle:
+                return cycle
+
+    return []

--- a/tests/test_umber.py
+++ b/tests/test_umber.py
@@ -1,0 +1,41 @@
+from playground.umber import find_cycle
+
+
+def test_find_cycle_returns_empty_list_for_acyclic_graph() -> None:
+    graph = {
+        "build": ["lint", "test"],
+        "lint": ["format"],
+        "test": ["package"],
+    }
+
+    assert find_cycle(graph) == []
+
+
+def test_find_cycle_reports_simple_cycle() -> None:
+    graph = {
+        "api": ["service"],
+        "service": ["database"],
+        "database": ["api"],
+    }
+
+    assert find_cycle(graph) == ["api", "service", "database", "api"]
+
+
+def test_find_cycle_includes_dependency_only_nodes() -> None:
+    graph = {
+        "root": ["leaf"],
+    }
+
+    assert find_cycle(graph) == []
+
+
+def test_find_cycle_selects_cycle_deterministically() -> None:
+    graph = {
+        "zeta": ["zeta"],
+        "alpha": ["beta", "gamma"],
+        "gamma": ["alpha"],
+        "beta": ["delta"],
+        "delta": ["beta"],
+    }
+
+    assert find_cycle(graph) == ["beta", "delta", "beta"]


### PR DESCRIPTION
## Summary
- add isolated umber dependency cycle reporter
- return a deterministic discovered cycle with matching first and last nodes
- cover acyclic, simple cycle, dependency-only node, and deterministic selection cases

## Validation
- python3 -m pytest tests/test_umber.py
- python3 -m pip install -e .[test] --break-system-packages
- pytest
- git diff --check

Closes #176