### PR TITLE
Add beryl range compactor

### DIFF
--- a/src/playground/beryl.py
+++ b/src/playground/beryl.py
@@ -1,0 +1,29 @@
+def compact_ranges(values: list[int]) -> list[str]:
+    """Return sorted integers compacted into contiguous ranges."""
+    compacted: list[str] = []
+    unique_values = sorted(set(values))
+
+    if not unique_values:
+        return compacted
+
+    start = previous = unique_values[0]
+
+    for value in unique_values[1:]:
+        if value == previous + 1:
+            previous = value
+            continue
+
+        compacted.append(_format_range(start, previous))
+        start = previous = value
+
+    compacted.append(_format_range(start, previous))
+    return compacted
+
+
+def _format_range(start: int, end: int) -> str:
+    if start == end:
+        return str(start)
+    return f"{start}-{end}"
+
+
+__all__ = ["compact_ranges"]

--- a/tests/test_beryl.py
+++ b/tests/test_beryl.py
@@ -1,0 +1,21 @@
+from playground.beryl import compact_ranges
+
+
+def test_compact_ranges_returns_empty_list_for_empty_input() -> None:
+    assert compact_ranges([]) == []
+
+
+def test_compact_ranges_removes_duplicates() -> None:
+    assert compact_ranges([2, 2, 3, 3, 5]) == ["2-3", "5"]
+
+
+def test_compact_ranges_sorts_unsorted_input() -> None:
+    assert compact_ranges([9, 1, 3, 2, 8]) == ["1-3", "8-9"]
+
+
+def test_compact_ranges_keeps_singletons_as_plain_strings() -> None:
+    assert compact_ranges([1, 3, 5]) == ["1", "3", "5"]
+
+
+def test_compact_ranges_collapses_contiguous_runs() -> None:
+    assert compact_ranges([1, 2, 3, 7, 8, 10]) == ["1-3", "7-8", "10"]


### PR DESCRIPTION
Closes #183

## Summary
- add isolated beryl compact_ranges helper
- cover empty input, duplicates, unsorted input, singletons, and contiguous runs

## Validation
- pytest
- git diff --check
- python3 -m pip install -e '.[test]' blocked by PEP 668 externally-managed-environment