### PR TITLE
Add citrine slug allocator

### DIFF
--- a/src/playground/citrine.py
+++ b/src/playground/citrine.py
@@ -1,0 +1,22 @@
+import re
+
+
+_NON_ALNUM = re.compile(r"[^a-z0-9]+")
+
+
+def allocate_slug(title: str, existing: set[str]) -> str:
+    """Return a normalized slug that is not present in existing."""
+    base_slug = _NON_ALNUM.sub("-", title.strip().lower()).strip("-") or "item"
+
+    if base_slug not in existing:
+        return base_slug
+
+    suffix = 2
+    while True:
+        candidate = f"{base_slug}-{suffix}"
+        if candidate not in existing:
+            return candidate
+        suffix += 1
+
+
+__all__ = ["allocate_slug"]

--- a/tests/test_citrine.py
+++ b/tests/test_citrine.py
@@ -1,0 +1,23 @@
+from playground.citrine import allocate_slug
+
+
+def test_allocate_slug_normalizes_title() -> None:
+    assert allocate_slug("  Hello, Citrine Slug!!  ", set()) == "hello-citrine-slug"
+
+
+def test_allocate_slug_uses_item_for_blank_normalized_title() -> None:
+    assert allocate_slug(" !!! ", set()) == "item"
+
+
+def test_allocate_slug_numbers_collisions_until_unique() -> None:
+    existing = {"release-notes", "release-notes-2", "release-notes-3"}
+
+    assert allocate_slug("Release Notes", existing) == "release-notes-4"
+
+
+def test_allocate_slug_does_not_mutate_existing() -> None:
+    existing = {"item"}
+    before = set(existing)
+
+    assert allocate_slug(" ", existing) == "item-2"
+    assert existing == before


### PR DESCRIPTION
Closes #184

## Summary
- add isolated citrine slug allocator
- cover normalization, blank fallback, collision numbering, and existing immutability

## Validation
- python3 -m pip install -e .[test] (blocked by PEP 668 externally-managed-environment on system Python)
- PIP_CACHE_DIR=/tmp/pip-cache python3 -m pip install --target /tmp/github184-target-current --no-build-isolation -e .[test]
- pytest tests/test_citrine.py
- pytest
- git diff --check origin/main...HEAD