### PR TITLE
Add dune window summarizer

### DIFF
--- a/src/playground/dune.py
+++ b/src/playground/dune.py
@@ -1,0 +1,19 @@
+def summarize_window(values: list[float], size: int) -> list[dict[str, float]]:
+    """Return min, max, and average summaries for full sliding windows."""
+    if not values:
+        return []
+
+    window_size = max(size, 1)
+    summaries: list[dict[str, float]] = []
+
+    for start in range(len(values) - window_size + 1):
+        window = values[start : start + window_size]
+        summaries.append(
+            {
+                "min": float(min(window)),
+                "max": float(max(window)),
+                "average": sum(window) / window_size,
+            }
+        )
+
+    return summaries

--- a/tests/test_dune.py
+++ b/tests/test_dune.py
@@ -1,0 +1,27 @@
+from playground.dune import summarize_window
+
+
+def test_summarize_window_returns_empty_for_empty_values() -> None:
+    assert summarize_window([], 3) == []
+
+
+def test_summarize_window_clamps_size_to_one() -> None:
+    assert summarize_window([2.0, 4.0, 8.0], 0) == [
+        {"min": 2.0, "max": 2.0, "average": 2.0},
+        {"min": 4.0, "max": 4.0, "average": 4.0},
+        {"min": 8.0, "max": 8.0, "average": 8.0},
+    ]
+
+
+def test_summarize_window_exact_size_window() -> None:
+    assert summarize_window([1.0, 3.0, 5.0], 3) == [
+        {"min": 1.0, "max": 5.0, "average": 3.0}
+    ]
+
+
+def test_summarize_window_multiple_sliding_windows() -> None:
+    assert summarize_window([1.0, 4.0, 2.0, 8.0], 2) == [
+        {"min": 1.0, "max": 4.0, "average": 2.5},
+        {"min": 2.0, "max": 4.0, "average": 3.0},
+        {"min": 2.0, "max": 8.0, "average": 5.0},
+    ]


### PR DESCRIPTION
## Summary
- add isolated playground.dune.summarize_window for numeric sliding windows
- clamp window size to at least 1 and return min, max, and average for each full window
- cover empty values, size clamping, exact-size windows, and multiple sliding windows

## Validation
- pytest tests/test_dune.py
- PYTHONUSERBASE=/tmp/playground185-userbase PIP_BREAK_SYSTEM_PACKAGES=1 python3 -m pip install --user -e .[test]
- pytest
- git diff --cached --check

Closes #185