### PR TITLE
Add emberly header parser

### DIFF
--- a/src/playground/emberly.py
+++ b/src/playground/emberly.py
@@ -1,0 +1,15 @@
+def parse_headers(lines: list[str]) -> dict[str, str]:
+    headers: dict[str, str] = {}
+
+    for line in lines:
+        if not line.strip() or ":" not in line:
+            continue
+
+        key, value = line.split(":", 1)
+        clean_key = key.strip().lower()
+        if not clean_key:
+            continue
+
+        headers[clean_key] = value.strip()
+
+    return headers

--- a/tests/test_emberly.py
+++ b/tests/test_emberly.py
@@ -1,0 +1,25 @@
+from playground.emberly import parse_headers
+
+
+def test_parse_headers_ignores_blank_no_colon_and_blank_keys() -> None:
+    assert parse_headers(["", "   ", "No colon", "  : value", "Host: example.com"]) == {
+        "host": "example.com",
+    }
+
+
+def test_parse_headers_trims_and_normalizes_keys_and_values() -> None:
+    assert parse_headers(["  Content-Type  :  text/plain  "]) == {
+        "content-type": "text/plain",
+    }
+
+
+def test_parse_headers_last_duplicate_key_wins() -> None:
+    assert parse_headers(["X-Mode: first", " x-mode : second"]) == {
+        "x-mode": "second",
+    }
+
+
+def test_parse_headers_keeps_colons_inside_values() -> None:
+    assert parse_headers(["Location: https://example.com/a:b"]) == {
+        "location": "https://example.com/a:b",
+    }


### PR DESCRIPTION
## Summary
- Add isolated `parse_headers` helper in `src/playground/emberly.py`
- Add focused tests for invalid lines, trimming, duplicate overrides, and colons inside values

## Validation
- `python3 -m pip install -e .[test]` (blocked by PEP 668 externally-managed environment)
- `python3 -m pip install --target /tmp/github186-pydeps -e .[test]`
- `pytest tests/test_emberly.py`
- `pytest`

Closes #186