### PR TITLE
Add ferrum retry schedule

### DIFF
--- a/src/playground/ferrum.py
+++ b/src/playground/ferrum.py
@@ -1,0 +1,18 @@
+def retry_delays(
+    attempts: int,
+    initial: int = 1,
+    multiplier: int = 2,
+    maximum: int = 60,
+) -> list[int]:
+    """Return capped exponential retry delays."""
+    safe_attempts = max(0, attempts)
+    delay = max(1, initial)
+    factor = max(1, multiplier)
+    cap = max(1, maximum)
+
+    delays = []
+    for _ in range(safe_attempts):
+        delays.append(min(delay, cap))
+        delay *= factor
+
+    return delays

--- a/tests/test_ferrum.py
+++ b/tests/test_ferrum.py
@@ -1,0 +1,27 @@
+from playground.ferrum import retry_delays
+
+
+def test_retry_delays_returns_empty_list_for_zero_attempts() -> None:
+    assert retry_delays(0) == []
+
+
+def test_retry_delays_clamps_negative_attempts_to_zero() -> None:
+    assert retry_delays(-3) == []
+
+
+def test_retry_delays_uses_default_exponential_growth() -> None:
+    assert retry_delays(5) == [1, 2, 4, 8, 16]
+
+
+def test_retry_delays_caps_delays_at_maximum() -> None:
+    assert retry_delays(5, initial=10, multiplier=3, maximum=25) == [
+        10,
+        25,
+        25,
+        25,
+        25,
+    ]
+
+
+def test_retry_delays_clamps_parameters_to_at_least_one() -> None:
+    assert retry_delays(4, initial=0, multiplier=0, maximum=0) == [1, 1, 1, 1]


### PR DESCRIPTION
## Summary\n- Add isolated ferrum retry delay helper\n- Cover zero attempts, default growth, max cap, and clamped parameters\n\n## Validation\n- pytest tests/test_ferrum.py\n- python3 -m pip install -e .[test] (blocked by PEP 668 externally-managed-environment)\n- UV_CACHE_DIR=/tmp/uv-cache uv pip install --python /tmp/github187-ferrum-venv/bin/python -e '/tmp/github187-src[test]' && /tmp/github187-ferrum-venv/bin/python -m pytest\n- pytest\n\nFixes #187