### PR TITLE
Add jolt percentile bucket helper

### DIFF
--- a/src/playground/jolt.py
+++ b/src/playground/jolt.py
@@ -1,0 +1,11 @@
+def percentile_bucket(
+    value: float, boundaries: list[float] | tuple[float, ...]
+) -> str:
+    """Return the percentile bucket label for a value and boundary set."""
+    sorted_boundaries = sorted(boundaries)
+
+    for index, boundary in enumerate(sorted_boundaries):
+        if value <= boundary:
+            return f"p{index}"
+
+    return f"p{len(sorted_boundaries)}"

--- a/tests/test_jolt.py
+++ b/tests/test_jolt.py
@@ -1,0 +1,24 @@
+from playground.jolt import percentile_bucket
+
+
+def test_percentile_bucket_sorts_unsorted_boundaries() -> None:
+    assert percentile_bucket(15.0, [30.0, 10.0, 20.0]) == "p1"
+
+
+def test_percentile_bucket_uses_lower_bucket_for_exact_boundaries() -> None:
+    boundaries = (10.0, 20.0, 30.0)
+
+    assert percentile_bucket(10.0, boundaries) == "p0"
+    assert percentile_bucket(20.0, boundaries) == "p1"
+    assert percentile_bucket(30.0, boundaries) == "p2"
+
+
+def test_percentile_bucket_returns_last_bucket_above_all_boundaries() -> None:
+    assert percentile_bucket(31.0, [10.0, 20.0, 30.0]) == "p3"
+
+
+def test_percentile_bucket_does_not_mutate_input_boundaries() -> None:
+    boundaries = [30.0, 10.0, 20.0]
+
+    assert percentile_bucket(15.0, boundaries) == "p1"
+    assert boundaries == [30.0, 10.0, 20.0]


### PR DESCRIPTION
## Summary
- Add `playground.jolt.percentile_bucket` for sorted percentile boundary bucketing.
- Add focused jolt tests for unsorted input, exact-boundary behavior, above-all behavior, and non-mutating input handling.

## Validation
- `python3 -m pip install -e .[test]` (blocked by PEP 668 externally-managed-environment on this host)
- `PYTHONPATH=src pytest tests/test_jolt.py` (4 passed)
- `UV_CACHE_DIR=/tmp/uv-cache uv venv /tmp/playground195-venv && UV_CACHE_DIR=/tmp/uv-cache uv pip install --python /tmp/playground195-venv/bin/python -e '.[test]' && /tmp/playground195-venv/bin/python -m pytest` (442 passed)

Closes #195
