### PR TITLE
Add glyph token formatter

### DIFF
--- a/src/playground/glyph.py
+++ b/src/playground/glyph.py
@@ -1,0 +1,4 @@
+def format_glyph_token(name: str | None = None) -> str:
+    """Return the Glyph token for smoke tests."""
+    clean_name = name.strip() if name is not None else ""
+    return f"Glyph: {clean_name or 'Sprints'}"

--- a/tests/test_glyph.py
+++ b/tests/test_glyph.py
@@ -1,0 +1,13 @@
+from playground.glyph import format_glyph_token
+
+
+def test_format_glyph_token_uses_default_name() -> None:
+    assert format_glyph_token() == "Glyph: Sprints"
+
+
+def test_format_glyph_token_trims_custom_name() -> None:
+    assert format_glyph_token("  Hermes  ") == "Glyph: Hermes"
+
+
+def test_format_glyph_token_uses_default_for_blank_name() -> None:
+    assert format_glyph_token("   ") == "Glyph: Sprints"


### PR DESCRIPTION
## Summary
- Add isolated `format_glyph_token` helper in `src/playground/glyph.py`.
- Add focused tests for default, trimmed custom, and blank fallback behavior.

## Validation
- `python3 -m pip install -e .[test]` attempted; blocked by host PEP 668 `externally-managed-environment`.
- `pytest` -> 441 passed.
- `UV_CACHE_DIR=/tmp/uv-cache-glyph-193 uv pip install --python /tmp/playground-glyph-193-venv/bin/python -e .[test]` -> installed package in temp venv.
- `/tmp/playground-glyph-193-venv/bin/python -m pytest` -> 441 passed.

Closes #193