### PR TITLE
Add ivor key normalizer

### DIFF
--- a/src/playground/ivor.py
+++ b/src/playground/ivor.py
@@ -1,0 +1,14 @@
+import re
+
+
+def normalize_ivor_key(value: str | None = None) -> str:
+    """Return a normalized Ivor key for smoke tests."""
+    if value is None:
+        clean_value = "sprints"
+    else:
+        clean_value = value.strip()
+
+    if not clean_value:
+        clean_value = "sprints"
+
+    return re.sub(r"\s+", "-", clean_value.lower()).strip("-")

--- a/tests/test_ivor.py
+++ b/tests/test_ivor.py
@@ -1,0 +1,17 @@
+from playground.ivor import normalize_ivor_key
+
+
+def test_normalize_ivor_key_uses_default_fallback() -> None:
+    assert normalize_ivor_key() == "sprints"
+
+
+def test_normalize_ivor_key_trims_and_lowercases_mixed_case_input() -> None:
+    assert normalize_ivor_key("  Ivor Key  ") == "ivor-key"
+
+
+def test_normalize_ivor_key_replaces_repeated_whitespace_with_hyphen() -> None:
+    assert normalize_ivor_key("Ivor   Key\tAlpha\nBeta") == "ivor-key-alpha-beta"
+
+
+def test_normalize_ivor_key_uses_blank_fallback() -> None:
+    assert normalize_ivor_key("   \t\n  ") == "sprints"


### PR DESCRIPTION
## Summary
- Add isolated `normalize_ivor_key` helper for ivor keys.
- Cover default fallback, trimmed mixed-case input, repeated whitespace, and blank fallback.

## Validation
- `python3 -m pip install -e .[test]` (blocked by PEP 668 externally-managed environment)
- `pytest`
- `UV_CACHE_DIR=/tmp/uv-cache uv pip install --python /tmp/github194-ivor-venv/bin/python -e '.[test]'`\n- `UV_CACHE_DIR=/tmp/uv-cache uv run --python /tmp/github194-ivor-venv/bin/python pytest tests/test_ivor.py`\n\nCloses #194