### PR TITLE
Add knoll dependency depth calculator

### DIFF
--- a/src/playground/knoll.py
+++ b/src/playground/knoll.py
@@ -2,6 +2,7 @@ def dependency_depths(
     graph: dict[str, list[str] | tuple[str, ...]],
 ) -> dict[str, int]:
     """Return the longest dependency-chain depth for each node in graph."""
+    # Normalize dependencies so dependency-only nodes can be traversed like keys.
     dependencies_by_node: dict[str, tuple[str, ...]] = {
         node: tuple(dependencies) for node, dependencies in graph.items()
     }
@@ -10,6 +11,7 @@ def dependency_depths(
             dependencies_by_node.setdefault(dependency, ())
 
     depths: dict[str, int] = {}
+    # Track the DFS path separately from completed nodes to catch back edges.
     visiting: set[str] = set()
     visited: set[str] = set()
 
@@ -21,6 +23,7 @@ def dependency_depths(
 
         visiting.add(node)
         dependencies = dependencies_by_node[node]
+        # A node's depth is one more than its deepest direct dependency.
         if dependencies:
             depth = 1 + max(depth_for(dependency) for dependency in dependencies)
         else:

--- a/src/playground/knoll.py
+++ b/src/playground/knoll.py
@@ -1,0 +1,36 @@
+def dependency_depths(
+    graph: dict[str, list[str] | tuple[str, ...]],
+) -> dict[str, int]:
+    """Return the longest dependency-chain depth for each node in graph."""
+    dependencies_by_node: dict[str, tuple[str, ...]] = {
+        node: tuple(dependencies) for node, dependencies in graph.items()
+    }
+    for dependencies in graph.values():
+        for dependency in dependencies:
+            dependencies_by_node.setdefault(dependency, ())
+
+    depths: dict[str, int] = {}
+    visiting: set[str] = set()
+    visited: set[str] = set()
+
+    def depth_for(node: str) -> int:
+        if node in visited:
+            return depths[node]
+        if node in visiting:
+            raise ValueError("cycle detected")
+
+        visiting.add(node)
+        dependencies = dependencies_by_node[node]
+        if dependencies:
+            depth = 1 + max(depth_for(dependency) for dependency in dependencies)
+        else:
+            depth = 0
+        visiting.remove(node)
+        visited.add(node)
+        depths[node] = depth
+        return depth
+
+    for node in dependencies_by_node:
+        depth_for(node)
+
+    return depths

--- a/tests/test_knoll.py
+++ b/tests/test_knoll.py
@@ -1,0 +1,52 @@
+import pytest
+
+from playground.knoll import dependency_depths
+
+
+def test_dependency_depths_for_simple_chain() -> None:
+    graph = {
+        "app": ["library"],
+        "library": ["foundation"],
+        "foundation": [],
+    }
+
+    assert dependency_depths(graph) == {
+        "app": 2,
+        "library": 1,
+        "foundation": 0,
+    }
+
+
+def test_dependency_depths_use_longest_branch() -> None:
+    graph = {
+        "app": ("short", "long"),
+        "short": ["leaf"],
+        "long": ["middle"],
+        "middle": ["leaf"],
+        "leaf": [],
+    }
+
+    assert dependency_depths(graph) == {
+        "app": 3,
+        "short": 1,
+        "long": 2,
+        "middle": 1,
+        "leaf": 0,
+    }
+
+
+def test_dependency_depths_include_dependency_only_nodes() -> None:
+    assert dependency_depths({"app": ["plugin"]}) == {
+        "app": 1,
+        "plugin": 0,
+    }
+
+
+def test_dependency_depths_raise_value_error_for_cycle() -> None:
+    graph = {
+        "app": ["library"],
+        "library": ["app"],
+    }
+
+    with pytest.raises(ValueError):
+        dependency_depths(graph)


### PR DESCRIPTION
## Summary
- Add `dependency_depths` in isolated `src/playground/knoll.py`.
- Cover simple chains, longest branching depth, dependency-only nodes, and cycle detection in `tests/test_knoll.py`.

## Validation
- `pytest tests/test_knoll.py` -> 4 passed
- `UV_CACHE_DIR=/tmp/github196-uv-cache uv pip install --python /tmp/github196-knoll-uv/bin/python -e '.[test]'` -> installed editable package; warned that the package has no `test` extra\n- `/tmp/github196-knoll-uv/bin/pytest` -> 445 passed\n\nCloses #196