### PR TITLE
Add larch extension grouper

### DIFF
--- a/src/playground/larch.py
+++ b/src/playground/larch.py
@@ -1,0 +1,13 @@
+from pathlib import PurePath
+
+
+def group_by_extension(paths: list[str] | tuple[str, ...]) -> dict[str, list[str]]:
+    """Group paths by lowercase extension without the leading dot."""
+    grouped: dict[str, list[str]] = {}
+
+    for path in paths:
+        suffix = PurePath(path).suffix
+        extension = suffix[1:].lower() if suffix else ""
+        grouped.setdefault(extension, []).append(path)
+
+    return grouped

--- a/tests/test_larch.py
+++ b/tests/test_larch.py
@@ -1,0 +1,35 @@
+from playground.larch import group_by_extension
+
+
+def test_group_by_extension_lowercases_mixed_case_extensions() -> None:
+    paths = ["notes.TXT", "archive.tar.GZ", "photo.JpEg"]
+
+    assert group_by_extension(paths) == {
+        "txt": ["notes.TXT"],
+        "gz": ["archive.tar.GZ"],
+        "jpeg": ["photo.JpEg"],
+    }
+
+
+def test_group_by_extension_uses_empty_key_for_paths_without_extension() -> None:
+    paths = ["README", "bin/tool", ".env"]
+
+    assert group_by_extension(paths) == {"": ["README", "bin/tool", ".env"]}
+
+
+def test_group_by_extension_preserves_order_for_repeated_extensions() -> None:
+    paths = ["first.py", "notes.md", "second.PY", "third.py"]
+
+    assert group_by_extension(paths) == {
+        "py": ["first.py", "second.PY", "third.py"],
+        "md": ["notes.md"],
+    }
+
+
+def test_group_by_extension_accepts_tuple_input() -> None:
+    paths = ("src/app.py", "tests/test_app.PY", "LICENSE")
+
+    assert group_by_extension(paths) == {
+        "py": ["src/app.py", "tests/test_app.PY"],
+        "": ["LICENSE"],
+    }


### PR DESCRIPTION
## Summary
- Add `playground.larch.group_by_extension` for grouping paths by lowercase extension.
- Add focused tests for mixed-case extensions, no-extension paths, repeated extension ordering, and tuple input.

## Validation
- `python3 -m pip install -e .[test]` (blocked by PEP 668 externally-managed environment)
- `python3 -m pip install --target /tmp/playground-larch-pydeps-197 -e .[test]`
- `PYTHONPATH=/tmp/playground-larch-pydeps-197 python3 -m pytest`
- `pytest`
- `git diff --check`

Closes #197